### PR TITLE
feat: split business logic into services

### DIFF
--- a/packages/extension-chrome/src/rpc/server.ts
+++ b/packages/extension-chrome/src/rpc/server.ts
@@ -3,6 +3,7 @@ import browser from 'webextension-polyfill';
 import { errors } from '@nexus-wallet/utils';
 import { RpcMethods, ServerParams } from './types';
 import { JSONRPCServer } from 'json-rpc-2.0';
+import { createServicesFactory } from '../services';
 
 export const server = new JSONRPCServer<ServerParams>();
 
@@ -14,8 +15,10 @@ export function addMethod<K extends keyof RpcMethods>(
 }
 
 export function createRpcServerParams(payload: { endpoint: Endpoint }): ServerParams {
+  let servicesFactory = createServicesFactory();
+
   return {
-    async getRequesterAppInfo() {
+    getRequesterAppInfo: async () => {
       const tab = await browser.tabs.get(payload.endpoint.tabId);
       if (!tab.url || !tab.favIconUrl) {
         errors.throwError(
@@ -24,5 +27,7 @@ export function createRpcServerParams(payload: { endpoint: Endpoint }): ServerPa
       }
       return { url: tab.url, favIconUrl: tab.favIconUrl };
     },
+
+    resolveService: (k) => servicesFactory.get(k),
   };
 }

--- a/packages/extension-chrome/src/rpc/types.ts
+++ b/packages/extension-chrome/src/rpc/types.ts
@@ -1,3 +1,7 @@
+import { Script } from '@ckb-lumos/lumos';
+import { Promisable } from '@nexus-wallet/types/lib/base';
+import { Services } from '../services';
+
 interface RpcCall<Params, Result> {
   params: Params;
   result: Result;
@@ -7,11 +11,14 @@ export interface RpcMethods {
   wallet_enable: RpcCall<void, void>;
   wallet_isEnabled: RpcCall<void, boolean>;
   wallet_getNetworkName: RpcCall<void, string>;
+
+  wallet_fullOwnership_getUnusedLocks: RpcCall<void, Script[]>;
 }
 
 /**
  * the RPC server handler second params
  */
 export interface ServerParams {
+  resolveService<K extends keyof Services>(name: K): Promisable<Services[K]>;
   getRequesterAppInfo(): Promise<{ url: string; favIconUrl: string }>;
 }

--- a/packages/extension-chrome/src/rpc/walletImpl.ts
+++ b/packages/extension-chrome/src/rpc/walletImpl.ts
@@ -1,56 +1,30 @@
 import { addMethod } from './server';
-import browser from 'webextension-polyfill';
 import { errors } from '@nexus-wallet/utils';
 
-const NOTIFICATION_WIDTH = 360;
-const NOTIFICATION_HEIGHT = 600;
+addMethod('wallet_enable', async (_, { getRequesterAppInfo, resolveService }) => {
+  const grantService = await resolveService('grantService');
+  const { url } = await getRequesterAppInfo();
 
-addMethod('wallet_enable', async (_, { getRequesterAppInfo }) => {
-  const lastFocused = await browser.windows.getLastFocused();
+  const granted = await grantService.getIsGranted({ url });
+  if (granted) return;
 
-  const notification = await browser.windows.create({
-    type: 'popup',
-    focused: true,
-    top: lastFocused.top,
-    left: lastFocused.left! + (lastFocused.width! - 360),
-    width: NOTIFICATION_WIDTH,
-    height: NOTIFICATION_HEIGHT,
-    url: 'notification.html',
-  });
+  const notificationService = await resolveService('notificationService');
+  try {
+    await notificationService.requestGrant({ url });
+  } catch {
+    errors.throwError('User has rejected');
+  }
 
-  const notificationTabId = notification.tabs?.[0]?.id;
+  await grantService.grant({ url });
+});
 
-  type MessageListener = Parameters<typeof browser.runtime.onMessage.addListener>[0];
-  const getRequesterAppInfoListener: MessageListener = (message, sender) =>
-    new Promise(async (sendResponse) => {
-      if (notificationTabId !== sender.tab?.id) return;
-      if (message.method !== 'getRequesterAppInfo') return;
-
-      const { url } = await getRequesterAppInfo();
-      sendResponse({ url });
-      browser.runtime.onMessage.removeListener(getRequesterAppInfoListener);
-    });
-
-  return new Promise((resolve, reject) => {
-    const userHasEnabledWalletListener: MessageListener = (message, sender) =>
-      new Promise((sendResponse) => {
-        if (notificationTabId !== sender.tab?.id) return;
-        if (message.method !== 'userHasEnabledWallet') return;
-
-        sendResponse(void 0);
-        browser.runtime.onMessage.removeListener(userHasEnabledWalletListener);
-        resolve();
-      });
-
-    browser.runtime.onMessage.addListener(getRequesterAppInfoListener);
-    browser.runtime.onMessage.addListener(userHasEnabledWalletListener);
-
-    browser.windows.onRemoved.addListener((windowId) => {
-      if (windowId === notification.id) {
-        browser.runtime.onMessage.removeListener(getRequesterAppInfoListener);
-        browser.runtime.onMessage.removeListener(userHasEnabledWalletListener);
-        reject(errors);
-      }
-    });
-  });
+addMethod('wallet_fullOwnership_getUnusedLocks', () => {
+  // TODO implement me, this is just a mock
+  return [
+    {
+      codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      hashType: 'type',
+      args: '0x0000000000000000000000000000000000000000',
+    },
+  ];
 });

--- a/packages/extension-chrome/src/services/grant.ts
+++ b/packages/extension-chrome/src/services/grant.ts
@@ -1,0 +1,22 @@
+import { GrantService, Storage } from '@nexus-wallet/types';
+import { errors } from '@nexus-wallet/utils';
+
+export function createGrantService(payload: { storage: Storage<{ grant: string[] }> }): GrantService {
+  const { storage } = payload;
+
+  return {
+    async getIsGranted(payload) {
+      const grantedUrls = await storage.getItem('grant');
+      if (!grantedUrls) return false;
+      return grantedUrls.includes(payload.url);
+    },
+    async grant(payload) {
+      const grantedUrls = await storage.getItem('grant');
+      if (!grantedUrls) {
+        errors.throwError('Storage is not initialized');
+      }
+      grantedUrls.push(payload.url);
+      storage.setItem('grant', grantedUrls);
+    },
+  };
+}

--- a/packages/extension-chrome/src/services/index.ts
+++ b/packages/extension-chrome/src/services/index.ts
@@ -1,0 +1,42 @@
+import { GrantService, NotificationService, Promisable, Storage } from '@nexus-wallet/types';
+import { createGrantService } from './grant';
+import { createInMemoryStorage } from './storage';
+import { createNotificationService } from './notification';
+
+interface Schema {
+  grant: string[];
+}
+
+export interface Services {
+  storage: Storage<Schema>;
+  grantService: GrantService;
+  notificationService: NotificationService;
+}
+
+export interface ServicesFactory {
+  get<K extends keyof Services>(name: K): Promisable<Services[K]>;
+}
+
+export function createServicesFactory(): ServicesFactory {
+  const storage = createInMemoryStorage<Schema>();
+
+  const defaultStorage = {
+    grant: [],
+  };
+  storage.setAll({
+    ...defaultStorage,
+    ...storage.getAll(),
+  });
+
+  const services = {
+    storage,
+    grantService: createGrantService({ storage }),
+    notificationService: createNotificationService(),
+  };
+
+  return {
+    get(key) {
+      return services[key];
+    },
+  };
+}

--- a/packages/extension-chrome/src/services/notification.ts
+++ b/packages/extension-chrome/src/services/notification.ts
@@ -1,0 +1,65 @@
+import { NotificationService } from '@nexus-wallet/types';
+import { errors } from '@nexus-wallet/utils';
+import browser from 'webextension-polyfill';
+
+const NOTIFICATION_WIDTH = 360;
+const NOTIFICATION_HEIGHT = 600;
+
+export function createNotificationService(): NotificationService {
+  return {
+    async requestGrant({ url }) {
+      const lastFocused = await browser.windows.getLastFocused();
+
+      const notification = await browser.windows.create({
+        type: 'popup',
+        focused: true,
+        top: lastFocused.top,
+        left: lastFocused.left! + (lastFocused.width! - 360),
+        width: NOTIFICATION_WIDTH,
+        height: NOTIFICATION_HEIGHT,
+        url: 'notification.html',
+      });
+
+      const notificationTabId = notification.tabs?.[0]?.id;
+
+      type MessageListener = Parameters<typeof browser.runtime.onMessage.addListener>[0];
+      const getRequesterAppInfoListener: MessageListener = (message, sender) =>
+        new Promise(async (sendResponse) => {
+          if (notificationTabId !== sender.tab?.id) return;
+          if (message.method !== 'getRequesterAppInfo') return;
+
+          sendResponse({ url });
+          browser.runtime.onMessage.removeListener(getRequesterAppInfoListener);
+        });
+
+      return new Promise((resolve, reject) => {
+        const userHasEnabledWalletListener: MessageListener = (message, sender) =>
+          new Promise((sendResponse) => {
+            if (notificationTabId !== sender.tab?.id) return;
+            if (message.method !== 'userHasEnabledWallet') return;
+
+            sendResponse(void 0);
+            browser.runtime.onMessage.removeListener(userHasEnabledWalletListener);
+            resolve();
+          });
+
+        browser.runtime.onMessage.addListener(getRequesterAppInfoListener);
+        browser.runtime.onMessage.addListener(userHasEnabledWalletListener);
+
+        browser.windows.onRemoved.addListener((windowId) => {
+          if (windowId === notification.id) {
+            browser.runtime.onMessage.removeListener(getRequesterAppInfoListener);
+            browser.runtime.onMessage.removeListener(userHasEnabledWalletListener);
+            reject(errors);
+          }
+        });
+      });
+    },
+    requestSignTransaction() {
+      errors.unimplemented();
+    },
+    requestSignData() {
+      errors.unimplemented();
+    },
+  };
+}

--- a/packages/extension-chrome/src/services/storage.ts
+++ b/packages/extension-chrome/src/services/storage.ts
@@ -1,0 +1,37 @@
+import { Storage } from '@nexus-wallet/types';
+import { errors } from '@nexus-wallet/utils';
+
+interface InMemoryStorage<S> extends Storage<S> {
+  getAll(): S | undefined;
+
+  setAll(s: S): void;
+}
+
+export function createInMemoryStorage<S>(): InMemoryStorage<S> {
+  const store = new Map();
+
+  return {
+    getItem(key) {
+      return store.get(key);
+    },
+    hasItem(key) {
+      return store.has(key);
+    },
+    removeItem(key) {
+      return store.delete(key);
+    },
+    setItem(key, value) {
+      store.set(key, value);
+    },
+    getAll() {
+      return Object.fromEntries(store.entries());
+    },
+    setAll(s) {
+      if (!s) errors.throwError(`The storage cannot be set to ${s}`);
+
+      Object.entries(s).forEach(([key, value]) => {
+        store.set(key, value);
+      });
+    },
+  };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,4 @@
 export type { InjectedCkb, CkbProvider } from './injected';
+export type { OwnershipService, NotificationService, KeystoreService, GrantService } from './services';
+export type { Storage } from './storage';
+export type { Promisable, Paginate, Cursor } from './base';

--- a/packages/types/src/services/GrantService.ts
+++ b/packages/types/src/services/GrantService.ts
@@ -1,0 +1,15 @@
+import { Promisable } from '../base';
+
+export interface GrantService {
+  /**
+   * grant the app to access the wallet
+   * @param payload
+   */
+  grant(payload: { url: string }): Promisable<void>;
+
+  /**
+   * check if an app has been granted
+   * @param payload
+   */
+  getIsGranted(payload: { url: string }): Promisable<boolean>;
+}

--- a/packages/types/src/services/KeystoreService.ts
+++ b/packages/types/src/services/KeystoreService.ts
@@ -1,10 +1,74 @@
-import { Promisable } from '../base';
+import type { BytesLike } from '@ckb-lumos/codec';
+import type { HexString } from '@ckb-lumos/lumos';
+import type { Promisable } from '../base';
+import { Provider } from './common';
 
 export interface KeystoreService {
   /**
    * check if the keystore is initialized
    */
-  isInitialized(): Promisable<boolean>;
+  hasInitialized(): Promisable<boolean>;
 
-  initKeyStore(payload: { password: string; mnemonic: string }): Promisable<void>;
+  initKeyStore(payload: InitKeyStorePayload): Promisable<void>;
+
+  /**
+   * get an extended public key by a derivation path,
+   * if the corresponding extended public is not found in store or cache,
+   * the password will be required to derive the extended public key
+   * @param payload
+   */
+  getExtendedPublicKey(payload: GetExtendedPublicKeyPayload): Promisable<string>;
+
+  /**
+   *
+   * @param payload {@link SignMessagePayload}
+   */
+  signMessage(payload: SignMessagePayload): Promisable<HexString>;
 }
+
+interface GetExtendedPublicKeyPayload {
+  path: string;
+  password?: PasswordProvider;
+}
+
+/**
+ * A {@link https://ethereum.org/en/developers/docs/data-structures-and-encoding/web3-secret-storage/ Web3 secret storage} wrapper,
+ * to interact with the keystore
+ */
+export interface InitKeyStorePayload {
+  /**
+   * password to encrypt the keystore
+   */
+  password: string;
+  /**
+   * secret item to be encrypted
+   */
+  mnemonic: string;
+
+  /**
+   * non-hardened derivation path,
+   * the corresponding public key will be stored in plain text,
+   * for example, the BIP-44 path `m / 44'/ 309'/ 0'/ 0 / 0` will store the public key of
+   * `m / 44' / 309' / 0' / 0` (external) and `m/44'/ 309'/ 0'/ 1` (internal) in plain text
+   */
+  paths: NonHardenedPath[];
+}
+
+export interface SignMessagePayload {
+  /**
+   * message be to signed
+   */
+  message: BytesLike;
+  /**
+   * derivation path of the private key, will be used to sign the message
+   */
+  path: HardenedPath | NonHardenedPath;
+  /**
+   * password to decrypt the keystore
+   */
+  password: PasswordProvider;
+}
+
+type HardenedPath = string;
+type NonHardenedPath = string;
+type PasswordProvider = Provider<string>;

--- a/packages/types/src/services/KeystoreService.ts
+++ b/packages/types/src/services/KeystoreService.ts
@@ -1,0 +1,10 @@
+import { Promisable } from '../base';
+
+export interface KeystoreService {
+  /**
+   * check if the keystore is initialized
+   */
+  isInitialized(): Promisable<boolean>;
+
+  initKeyStore(payload: { password: string; mnemonic: string }): Promisable<void>;
+}

--- a/packages/types/src/services/NotificationService.ts
+++ b/packages/types/src/services/NotificationService.ts
@@ -1,0 +1,20 @@
+import { BytesLike } from '@ckb-lumos/codec';
+import { Transaction } from '@ckb-lumos/lumos';
+
+export interface NotificationService {
+  /**
+   * request user to approve for signing a transaction,
+   * will return a password to decrypt keystore if user approved and input the correct password
+   * @param payload
+   */
+  requestSignTransaction(payload: { tx: Transaction }): Promise<{ password: string }>;
+
+  /**
+   * request user to approve for signing binary data,
+   * will return a password to decrypt keystore if user approved and input the correct password
+   * @param payload
+   */
+  requestSignData(payload: { data: BytesLike }): Promise<{ password: string }>;
+
+  requestGrant(payload: { url: string }): Promise<void>;
+}

--- a/packages/types/src/services/OwnershipService.ts
+++ b/packages/types/src/services/OwnershipService.ts
@@ -1,0 +1,48 @@
+import type { BytesLike } from '@ckb-lumos/codec';
+import type { Cell, Script, Transaction } from '@ckb-lumos/lumos';
+import type { Bytes, Paginate } from '../base';
+
+export interface OwnershipService {
+  getLiveCells(payload?: GetPaginateItemsPayload): Promise<Paginate<Cell>>;
+
+  /**
+   * get unused locks
+   */
+  getUnusedLocks(payload: GetUnusedLocksPayload): Promise<Script[]>;
+
+  getUsedLocks(payload: GetUsedLocksPayload): Promise<Paginate<Script>>;
+
+  /**
+   * sign a transaction, only the secp256k1_blake2b lock will be signed
+   * @param payload
+   */
+  signTransaction(payload: SignTransactionPayload): Promise<GroupedSignature>;
+
+  /**
+   * sign binary data
+   * @param payload
+   */
+  signData(payload: SignDataPayload): Promise<Signature>;
+}
+
+interface GetPaginateItemsPayload {
+  cursor?: string;
+}
+
+interface GetUnusedLocksPayload {
+  change?: boolean;
+}
+
+interface GetUsedLocksPayload extends GetUnusedLocksPayload, GetPaginateItemsPayload {}
+
+interface SignTransactionPayload {
+  tx: Transaction;
+}
+
+export type SignDataPayload = {
+  data: BytesLike;
+  lock: Script;
+};
+
+export type GroupedSignature = [Script, Signature][];
+export type Signature = Bytes;

--- a/packages/types/src/services/common.ts
+++ b/packages/types/src/services/common.ts
@@ -1,0 +1,6 @@
+export type SyncProvider<T> = T | (() => T);
+export type AsyncProvider<T> = () => PromiseLike<T>;
+/**
+ * a compatible provider for both sync and async object
+ */
+export type Provider<T> = SyncProvider<T> | AsyncProvider<T>;

--- a/packages/types/src/services/index.ts
+++ b/packages/types/src/services/index.ts
@@ -1,0 +1,4 @@
+export type { GrantService } from './GrantService';
+export type { KeystoreService } from './KeystoreService';
+export type { NotificationService } from './NotificationService';
+export type { OwnershipService } from './OwnershipService';

--- a/packages/types/src/storage.ts
+++ b/packages/types/src/storage.ts
@@ -1,0 +1,11 @@
+import { Promisable } from './base';
+
+/**
+ * key-value storage
+ */
+export interface Storage<Schema> {
+  hasItem<K extends keyof Schema>(key: K): Promisable<boolean>;
+  getItem<K extends keyof Schema>(key: K): Promisable<Schema[K] | undefined>;
+  removeItem<K extends keyof Schema>(key: K): Promisable<boolean>;
+  setItem<K extends keyof Schema>(key: K, value: Schema[K]): Promisable<void>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,7 @@
      "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
      "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
      "emitDeclarationOnly": false,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+     "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */


### PR DESCRIPTION
resolved #29 

1. split business logic into several services
2. organize services and RPC server
3. a basic example of `wallet_enable` to show how to implement service and how to organize them
