### PR TITLE
add get used lock for ownership service

### DIFF
--- a/packages/extension-chrome/__tests__/services/ownership.ts
+++ b/packages/extension-chrome/__tests__/services/ownership.ts
@@ -86,3 +86,34 @@ it('ownership#get used locks return 1st lock and 6th lock', async () => {
     objects: [locks[0], locks[5]],
   });
 });
+
+it('ownership#sign data with 1st lock', async () => {
+  const keychain = Keychain.fromSeed(shortSeed);
+  const mockCallback = jest.fn().mockReturnValueOnce(Promise.resolve(1)).mockReturnValue(Promise.resolve(0));
+  const mockBackend: Backend = {
+    countTx: mockCallback,
+    nodeUri: '',
+    indexer: new CkbIndexer(''),
+  };
+  const mockAddressStorage = new DefaultAddressStorage(mockBackend, [], [], []);
+  const service = createOwnershipService(keychain, mockBackend, mockAddressStorage);
+  const usedExternalLocks = await service.getUsedLocks({});
+  mockAddressStorage.setUsedExternalAddresses([
+    {
+      path: '',
+      addressIndex: 0,
+      depth: 5,
+      pubkey: '',
+      blake160: '',
+      lock: usedExternalLocks.objects[0],
+    },
+  ]);
+
+  const message = '0x1234';
+  // TODO how to ensure the corresponding privatekey/message/signature is right?
+  const expectedSignature =
+    '0xee6b0c6598e02024f14788618abe7f92b5c60ce4376363f6e1b659993469833420c5dc884ae35675d86f7a6f14978b79844cee2b21ceda0d742070620a96091201';
+
+  const signature = await service.signData({ data: message, lock: locks[0] });
+  expect(signature).toEqual(expectedSignature);
+});

--- a/packages/extension-chrome/__tests__/services/ownership.ts
+++ b/packages/extension-chrome/__tests__/services/ownership.ts
@@ -1,0 +1,83 @@
+import { CkbIndexer } from '@ckb-lumos/ckb-indexer/lib/indexer';
+import { Keychain } from '@ckb-lumos/hd';
+import { publicKeyToBlake160 } from '@ckb-lumos/hd/lib/key';
+import { config, Script } from '@ckb-lumos/lumos';
+import { Backend } from '../../src/services/backend';
+import { createOwnershipService } from '../../src/services/ownership';
+
+// https://en.bitcoin.it/wiki/BIP_0032_TestVectors
+const shortSeed = Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex');
+
+const testKeychain = Keychain.fromSeed(shortSeed);
+
+const locks: Script[] = [];
+for (let index = 0; index < 10; index++) {
+  const currentKeychain = testKeychain.derivePath(`m/44'/309'/0'/0/${index}`);
+  const scriptArgs = publicKeyToBlake160(`0x${currentKeychain.publicKey.toString('hex')}`);
+  locks.push({
+    codeHash: config.getConfig().SCRIPTS!.SECP256K1_BLAKE160!.CODE_HASH,
+    hashType: 'type',
+    args: scriptArgs,
+  });
+}
+
+it('ownership#get 10 locks', async () => {
+  console.log('10 locks:', locks);
+  expect(locks.length).toBe(10);
+});
+
+it('ownership#get used locks return empty list', async () => {
+  const keychain = Keychain.fromSeed(shortSeed);
+  expect(keychain.privateKey.toString('hex')).toEqual(
+    'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
+  );
+
+  const mockBackend: Backend = {
+    countTx: async () => 0,
+    nodeUri: '',
+    indexer: new CkbIndexer(''),
+  };
+  const service = createOwnershipService(keychain, mockBackend);
+  const usedLocks = await service.getUsedLocks({});
+  expect(usedLocks).toEqual({ cursor: '', objects: [] });
+});
+
+it('ownership#get used locks return fisrt lock', async () => {
+  const keychain = Keychain.fromSeed(shortSeed);
+  const mockCallback = jest.fn().mockReturnValueOnce(Promise.resolve(1)).mockReturnValue(Promise.resolve(0));
+  const mockBackend: Backend = {
+    countTx: mockCallback,
+    nodeUri: '',
+    indexer: new CkbIndexer(''),
+  };
+  const service = createOwnershipService(keychain, mockBackend);
+  const usedLocks = await service.getUsedLocks({});
+  expect(usedLocks).toEqual({
+    cursor: '',
+    objects: [locks[0]],
+  });
+});
+it('ownership#get used locks return 1st lock and 6th lock', async () => {
+  const keychain = Keychain.fromSeed(shortSeed);
+  const mockCallback = jest
+    .fn()
+    .mockReturnValueOnce(Promise.resolve(1)) // m/44'/309'/0'/0/0
+    .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/1/0
+    .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/0/1
+    .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/0/2
+    .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/0/3
+    .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/0/4
+    .mockReturnValueOnce(Promise.resolve(1)) // m/44'/309'/0'/0/5
+    .mockReturnValue(Promise.resolve(0));
+  const mockBackend: Backend = {
+    countTx: mockCallback,
+    nodeUri: '',
+    indexer: new CkbIndexer(''),
+  };
+  const service = createOwnershipService(keychain, mockBackend);
+  const usedLocks = await service.getUsedLocks({});
+  expect(usedLocks).toEqual({
+    cursor: '',
+    objects: [locks[0], locks[5]],
+  });
+});

--- a/packages/extension-chrome/__tests__/services/ownership.ts
+++ b/packages/extension-chrome/__tests__/services/ownership.ts
@@ -22,7 +22,6 @@ for (let index = 0; index < 10; index++) {
 }
 
 it('ownership#get 10 locks', async () => {
-  console.log('10 locks:', locks);
   expect(locks.length).toBe(10);
 });
 

--- a/packages/extension-chrome/__tests__/services/ownership.ts
+++ b/packages/extension-chrome/__tests__/services/ownership.ts
@@ -51,7 +51,7 @@ const createMockKeystoreService = (
 
 it('ownership#get used locks return empty list', async () => {
   const mockBackend: Backend = {
-    countTx: async () => 0,
+    hasHistory: async () => false,
     nodeUri: '',
     indexer: new CkbIndexer(''),
   };
@@ -64,9 +64,9 @@ it('ownership#get used locks return empty list', async () => {
 });
 
 it('ownership#get used locks return fisrt lock', async () => {
-  const mockCallback = jest.fn().mockReturnValueOnce(Promise.resolve(1)).mockReturnValue(Promise.resolve(0));
+  const mockCallback = jest.fn().mockReturnValueOnce(Promise.resolve(true)).mockReturnValue(Promise.resolve(false));
   const mockBackend: Backend = {
-    countTx: mockCallback,
+    hasHistory: mockCallback,
     nodeUri: '',
     indexer: new CkbIndexer(''),
   };
@@ -82,14 +82,14 @@ it('ownership#get used locks return fisrt lock', async () => {
 });
 it('ownership#get used locks return 1st lock and 3rd lock', async () => {
   const mockBackend: Backend = {
-    countTx: jest
+    hasHistory: jest
       .fn()
-      .mockReturnValueOnce(Promise.resolve(1)) // m/44'/309'/0'/0/0
-      .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/1/0
-      .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/0/1
-      .mockReturnValueOnce(Promise.resolve(0)) // m/44'/309'/0'/1/1
-      .mockReturnValueOnce(Promise.resolve(1)) // m/44'/309'/0'/0/2
-      .mockReturnValue(Promise.resolve(0)),
+      .mockReturnValueOnce(Promise.resolve(true)) // m/44'/309'/0'/0/0
+      .mockReturnValueOnce(Promise.resolve(false)) // m/44'/309'/0'/1/0
+      .mockReturnValueOnce(Promise.resolve(false)) // m/44'/309'/0'/0/1
+      .mockReturnValueOnce(Promise.resolve(false)) // m/44'/309'/0'/1/1
+      .mockReturnValueOnce(Promise.resolve(true)) // m/44'/309'/0'/0/2
+      .mockReturnValue(Promise.resolve(false)),
     nodeUri: '',
     indexer: new CkbIndexer(''),
   };
@@ -109,9 +109,9 @@ it('ownership#get used locks return 1st lock and 3rd lock', async () => {
 });
 
 it('ownership#sign data with 1st lock', async () => {
-  const mockCallback = jest.fn().mockReturnValueOnce(Promise.resolve(1)).mockReturnValue(Promise.resolve(0));
+  const mockCallback = jest.fn().mockReturnValueOnce(Promise.resolve(true)).mockReturnValue(Promise.resolve(false));
   const mockBackend: Backend = {
-    countTx: mockCallback,
+    hasHistory: mockCallback,
     nodeUri: '',
     indexer: new CkbIndexer(''),
   };

--- a/packages/extension-chrome/__tests__/services/ownership.ts
+++ b/packages/extension-chrome/__tests__/services/ownership.ts
@@ -3,6 +3,7 @@ import { Keychain } from '@ckb-lumos/hd';
 import { publicKeyToBlake160 } from '@ckb-lumos/hd/lib/key';
 import { config, Script } from '@ckb-lumos/lumos';
 import { Backend } from '../../src/services/backend';
+import { DefaultAddressStorage } from '../../src/services/backend/addressStorage';
 import { createOwnershipService } from '../../src/services/ownership';
 
 // https://en.bitcoin.it/wiki/BIP_0032_TestVectors
@@ -36,7 +37,9 @@ it('ownership#get used locks return empty list', async () => {
     nodeUri: '',
     indexer: new CkbIndexer(''),
   };
-  const service = createOwnershipService(keychain, mockBackend);
+  const mockAddressStorage = new DefaultAddressStorage(mockBackend, [], [], []);
+
+  const service = createOwnershipService(keychain, mockBackend, mockAddressStorage);
   const usedLocks = await service.getUsedLocks({});
   expect(usedLocks).toEqual({ cursor: '', objects: [] });
 });
@@ -49,7 +52,9 @@ it('ownership#get used locks return fisrt lock', async () => {
     nodeUri: '',
     indexer: new CkbIndexer(''),
   };
-  const service = createOwnershipService(keychain, mockBackend);
+  const mockAddressStorage = new DefaultAddressStorage(mockBackend, [], [], []);
+
+  const service = createOwnershipService(keychain, mockBackend, mockAddressStorage);
   const usedLocks = await service.getUsedLocks({});
   expect(usedLocks).toEqual({
     cursor: '',
@@ -73,7 +78,8 @@ it('ownership#get used locks return 1st lock and 6th lock', async () => {
     nodeUri: '',
     indexer: new CkbIndexer(''),
   };
-  const service = createOwnershipService(keychain, mockBackend);
+  const mockAddressStorage = new DefaultAddressStorage(mockBackend, [], [], []);
+  const service = createOwnershipService(keychain, mockBackend, mockAddressStorage);
   const usedLocks = await service.getUsedLocks({});
   expect(usedLocks).toEqual({
     cursor: '',

--- a/packages/extension-chrome/src/services/backend/addressStorage.ts
+++ b/packages/extension-chrome/src/services/backend/addressStorage.ts
@@ -1,0 +1,93 @@
+import { Script } from '@ckb-lumos/base';
+import { Backend } from './index';
+export type AddressInfo = {
+  path: string;
+  pubkey: string;
+  blake160: string;
+  lock: Script;
+};
+
+export interface AddressStorage {
+  usedAddresses: {
+    externalAddresses: AddressInfo[];
+    changeAddresses: AddressInfo[];
+  };
+  unusedAddresses: AddressInfo[];
+  updateUnusedAddresses: () => Promise<void>;
+  getUsedExternalAddresses: () => AddressInfo[];
+  getUsedChangeAddresses: () => AddressInfo[];
+  getUnusedAddresses: () => Promise<AddressInfo[]>;
+
+  // getMaxAddressIndex: () => number;
+  getAddressInfoByLock: (lock: Script) => AddressInfo | undefined;
+}
+
+export class DefaultAddressStorage implements AddressStorage {
+  backend: Backend;
+  usedAddresses: {
+    externalAddresses: AddressInfo[];
+    changeAddresses: AddressInfo[];
+  };
+  unusedAddresses: AddressInfo[];
+
+  constructor(
+    backend: Backend,
+    usedExternalAddresses: AddressInfo[],
+    usedChangeAddresses: AddressInfo[],
+    unusedAddresses: AddressInfo[],
+  ) {
+    this.backend = backend;
+    this.usedAddresses = {
+      externalAddresses: usedExternalAddresses,
+      changeAddresses: usedChangeAddresses,
+    };
+    this.unusedAddresses = unusedAddresses;
+  }
+  getAddressInfoByLock(lock: Script): AddressInfo | undefined {
+    return (
+      this.usedAddresses.externalAddresses.find(
+        (address) => address.lock.codeHash === lock.codeHash && address.lock.args === lock.args,
+      ) ||
+      this.usedAddresses.changeAddresses.find(
+        (address) => address.lock.codeHash === lock.codeHash && address.lock.args === lock.args,
+      ) ||
+      this.unusedAddresses.find((address) => address.lock.codeHash === lock.codeHash && address.lock.args === lock.args)
+    );
+  }
+  getUsedExternalAddresses(): AddressInfo[] {
+    return this.usedAddresses.externalAddresses;
+  }
+  setUsedExternalAddresses(addresses: AddressInfo[]): void {
+    this.usedAddresses.externalAddresses = addresses;
+  }
+  getUsedChangeAddresses(): AddressInfo[] {
+    return this.usedAddresses.changeAddresses;
+  }
+  setUsedChangeAddresses(addresses: AddressInfo[]): void {
+    this.usedAddresses.changeAddresses = addresses;
+  }
+  async getUnusedAddresses(): Promise<AddressInfo[]> {
+    await this.updateUnusedAddresses();
+    return this.unusedAddresses;
+  }
+  setUnusedAddresses(addresses: AddressInfo[]): void {
+    this.unusedAddresses = addresses;
+  }
+
+  // check all unused addresses status and update the used/unused list
+  async updateUnusedAddresses(): Promise<void> {
+    const stillUnused: AddressInfo[] = [];
+    const newUsed: AddressInfo[] = [];
+    for (const address of this.unusedAddresses) {
+      const count = await this.backend.countTx(address.lock);
+      if (count > 0) {
+        newUsed.push(address);
+        // TODO need keychain to detect if change address is used too.
+      } else {
+        stillUnused.push(address);
+      }
+    }
+    this.unusedAddresses = stillUnused;
+    this.usedAddresses.externalAddresses.push(...newUsed);
+  }
+}

--- a/packages/extension-chrome/src/services/backend/addressStorage.ts
+++ b/packages/extension-chrome/src/services/backend/addressStorage.ts
@@ -83,13 +83,13 @@ export class DefaultAddressStorage implements AddressStorage {
     const newUsed: AddressInfo[] = [];
     const newChangeAddressUsed: AddressInfo[] = [];
     for (const address of this.unusedAddresses) {
-      const count = await this.backend.countTx(address.lock);
-      if (count > 0) {
+      const hasHistory = await this.backend.hasHistory(address.lock);
+      if (hasHistory) {
         newUsed.push(address);
         // detect if change address is used too.
         const addressIndex = address.addressIndex;
         const changeAddressInfo = getAddressInfo(keystoreService, true, addressIndex);
-        const changeTxcount = await this.backend.countTx(changeAddressInfo.lock);
+        const changeTxcount = await this.backend.hasHistory(changeAddressInfo.lock);
         !!changeTxcount && newChangeAddressUsed.push(changeAddressInfo);
       } else {
         stillUnused.push(address);

--- a/packages/extension-chrome/src/services/backend/index.ts
+++ b/packages/extension-chrome/src/services/backend/index.ts
@@ -3,7 +3,7 @@ import { Indexer, TransactionCollector } from '@ckb-lumos/ckb-indexer';
 export interface Backend {
   nodeUri: string;
   indexer: Indexer;
-  hasHistory: (script: Script) => Promise<boolean>;
+  hasHistory: (payload: { lock: Script }) => Promise<boolean>;
 }
 
 export class BackendProvider {
@@ -13,11 +13,11 @@ export class BackendProvider {
     return {
       nodeUri,
       indexer,
-      hasHistory: async (script: Script) => {
+      hasHistory: async (payload: { lock: Script }) => {
         const txCollector = new TransactionCollector(
           indexer,
           {
-            lock: script,
+            lock: payload.lock,
           },
           nodeUri,
         );

--- a/packages/extension-chrome/src/services/backend/index.ts
+++ b/packages/extension-chrome/src/services/backend/index.ts
@@ -3,7 +3,7 @@ import { Indexer, TransactionCollector } from '@ckb-lumos/ckb-indexer';
 export interface Backend {
   nodeUri: string;
   indexer: Indexer;
-  countTx: (script: Script) => Promise<number>;
+  hasHistory: (script: Script) => Promise<boolean>;
 }
 
 export class BackendProvider {
@@ -13,7 +13,7 @@ export class BackendProvider {
     return {
       nodeUri,
       indexer,
-      countTx: async (script: Script) => {
+      hasHistory: async (script: Script) => {
         const txCollector = new TransactionCollector(
           indexer,
           {
@@ -21,8 +21,12 @@ export class BackendProvider {
           },
           nodeUri,
         );
-        const count = await txCollector.count();
-        return count;
+        let hasRecord = false;
+        for await (const _ of txCollector.collect()) {
+          hasRecord = true;
+          break;
+        }
+        return hasRecord;
       },
     };
   }

--- a/packages/extension-chrome/src/services/backend/index.ts
+++ b/packages/extension-chrome/src/services/backend/index.ts
@@ -1,0 +1,29 @@
+import { Script } from '@ckb-lumos/base';
+import { Indexer, TransactionCollector } from '@ckb-lumos/ckb-indexer';
+export interface Backend {
+  nodeUri: string;
+  indexer: Indexer;
+  countTx: (script: Script) => Promise<number>;
+}
+
+export class BackendProvider {
+  public static getDefaultBackend(): Backend {
+    const nodeUri = 'http://127.0.0.1:8118/rpc';
+    const indexer = new Indexer(nodeUri);
+    return {
+      nodeUri,
+      indexer,
+      countTx: async (script: Script) => {
+        const txCollector = new TransactionCollector(
+          indexer,
+          {
+            lock: script,
+          },
+          nodeUri,
+        );
+        const count = await txCollector.count();
+        return count;
+      },
+    };
+  }
+}

--- a/packages/extension-chrome/src/services/backend/index.ts
+++ b/packages/extension-chrome/src/services/backend/index.ts
@@ -8,7 +8,7 @@ export interface Backend {
 
 export class BackendProvider {
   public static getDefaultBackend(): Backend {
-    const nodeUri = 'http://127.0.0.1:8118/rpc';
+    const nodeUri = 'https://testnet.ckb.dev';
     const indexer = new Indexer(nodeUri);
     return {
       nodeUri,

--- a/packages/extension-chrome/src/services/backend/utils.ts
+++ b/packages/extension-chrome/src/services/backend/utils.ts
@@ -1,0 +1,29 @@
+import { AddressInfo } from './addressStorage';
+import { Script } from '@ckb-lumos/base';
+import { publicKeyToBlake160 } from '@ckb-lumos/hd/lib/key';
+import { config } from '@ckb-lumos/lumos';
+import { Keychain } from '@ckb-lumos/hd';
+
+/**
+ *  This function will NOT call `derivePath` of keychain, The keychain should be aligned with the path passed in.
+ * @param keychain
+ * @param path
+ * @returns
+ */
+export function getAddressInfo(keychain: Keychain, path: string): AddressInfo {
+  // const Keychain = keychain.derivePath(path); // to achive better performance, don't call this
+  const scriptArgs = publicKeyToBlake160(`0x${keychain.publicKey.toString('hex')}`);
+  const lock: Script = {
+    codeHash: config.getConfig().SCRIPTS!.SECP256K1_BLAKE160!.CODE_HASH,
+    hashType: 'type',
+    args: scriptArgs,
+  };
+  return {
+    path,
+    addressIndex: keychain.index,
+    depth: keychain.depth,
+    pubkey: keychain.publicKey.toString('hex'),
+    blake160: scriptArgs,
+    lock,
+  };
+}

--- a/packages/extension-chrome/src/services/backend/utils.ts
+++ b/packages/extension-chrome/src/services/backend/utils.ts
@@ -1,8 +1,8 @@
+import { KeystoreService } from '@nexus-wallet/types';
 import { AddressInfo } from './addressStorage';
 import { Script } from '@ckb-lumos/base';
 import { publicKeyToBlake160 } from '@ckb-lumos/hd/lib/key';
 import { config } from '@ckb-lumos/lumos';
-import { Keychain } from '@ckb-lumos/hd';
 
 /**
  *  This function will NOT call `derivePath` of keychain, The keychain should be aligned with the path passed in.
@@ -10,19 +10,18 @@ import { Keychain } from '@ckb-lumos/hd';
  * @param path
  * @returns
  */
-export function getAddressInfo(keychain: Keychain, path: string): AddressInfo {
-  // const Keychain = keychain.derivePath(path); // to achive better performance, don't call this
-  const scriptArgs = publicKeyToBlake160(`0x${keychain.publicKey.toString('hex')}`);
+export function getAddressInfo(keystoreService: KeystoreService, change = false, index: number): AddressInfo {
+  const pubkey = keystoreService.getChildPubkey({ change, index });
+  const scriptArgs = publicKeyToBlake160(pubkey);
   const lock: Script = {
     codeHash: config.getConfig().SCRIPTS!.SECP256K1_BLAKE160!.CODE_HASH,
     hashType: 'type',
     args: scriptArgs,
   };
   return {
-    path,
-    addressIndex: keychain.index,
-    depth: keychain.depth,
-    pubkey: keychain.publicKey.toString('hex'),
+    path: `m/44'/309'/0'/${change ? 1 : 0}/${index}`,
+    addressIndex: index,
+    pubkey,
     blake160: scriptArgs,
     lock,
   };

--- a/packages/extension-chrome/src/services/ownership.ts
+++ b/packages/extension-chrome/src/services/ownership.ts
@@ -33,12 +33,12 @@ export function createOwnershipService(
       let currentGap = 0;
       for (let index = 0; ; index++) {
         const childScript: Script = generateChildScript(keystoreService, false, index);
-        const childScriptTxCount = await backend.countTx(childScript);
+        const childScriptHasHistory = await backend.hasHistory(childScript);
         // detect if there is a corresponding change address used also.
         const changeScript: Script = generateChildScript(keystoreService, true, index);
-        const changeScriptTxCount = await backend.countTx(changeScript);
-        !!changeScriptTxCount && changeScripts.push(changeScript);
-        if (childScriptTxCount > 0) {
+        const changeScriptHasHistory = await backend.hasHistory(changeScript);
+        changeScriptHasHistory && changeScripts.push(changeScript);
+        if (childScriptHasHistory) {
           externalScripts.push(childScript);
           currentGap = 0;
         } else {

--- a/packages/extension-chrome/src/services/ownership.ts
+++ b/packages/extension-chrome/src/services/ownership.ts
@@ -1,0 +1,75 @@
+import { Script } from '@ckb-lumos/base';
+import { Keychain } from '@ckb-lumos/hd';
+import { publicKeyToBlake160 } from '@ckb-lumos/hd/lib/key';
+import { OwnershipService, Paginate, GetUsedLocksPayload } from '@nexus-wallet/types';
+import { errors } from '@nexus-wallet/utils';
+import { config } from '@ckb-lumos/lumos';
+import { Backend } from './backend';
+
+const MAX_ADDRESS_GAP = 20;
+
+export function createOwnershipService(keychain: Keychain, backend: Backend): OwnershipService {
+  return {
+    getLiveCells: () => {
+      errors.unimplemented();
+    },
+    getUnusedLocks: () => {
+      errors.unimplemented();
+    },
+    getUsedLocks: async (payload: GetUsedLocksPayload): Promise<Paginate<Script>> => {
+      // refer to bip-44-account-discovery https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery
+      // 1. derive the first account's node (index = 0)
+      // 2. derive the external chain node of this account
+      // 3. scan addresses of the external chain; respect the gap limit (20)
+
+      // keychain for path: `m/44'/309'/0'/0`, parent keychain for first address path: `m/44'/309'/0'/0/0`
+      const masterKeyChain = keychain.derivePath(`m/44'/309'/0'/0`);
+      const externalScripts: Script[] = [];
+      const changeScripts: Script[] = [];
+      let currentGap = 0;
+      for (let index = 0; ; index++) {
+        const childScript: Script = generateChildScript(masterKeyChain, index);
+        const childScriptTxCount = await backend.countTx(childScript);
+        if (childScriptTxCount > 0) {
+          externalScripts.push(childScript);
+          currentGap = 0;
+          // if this external address is used, detect if there is a corresponding change address used also.
+          const changeScript: Script = generateChildScript(masterKeyChain, index);
+          const changeScriptTxCount = await backend.countTx(changeScript);
+          !!changeScriptTxCount && changeScripts.push(changeScript);
+        } else {
+          currentGap++;
+          if (currentGap >= MAX_ADDRESS_GAP) {
+            return payload.change
+              ? {
+                  cursor: '',
+                  objects: changeScripts,
+                }
+              : {
+                  cursor: '',
+                  objects: externalScripts,
+                };
+          }
+        }
+      }
+    },
+    signTransaction: () => {
+      errors.unimplemented();
+    },
+    signData: () => {
+      errors.unimplemented();
+    },
+  };
+
+  function generateChildScript(masterKeyChain: Keychain, index: number) {
+    const childKeyChain = masterKeyChain.deriveChild(index, false);
+    // args for SECP256K1_BLAKE160 script
+    const scriptArgs = publicKeyToBlake160(`0x${childKeyChain.publicKey.toString('hex')}`);
+    const childScript: Script = {
+      codeHash: config.getConfig().SCRIPTS!.SECP256K1_BLAKE160!.CODE_HASH,
+      hashType: 'type',
+      args: scriptArgs,
+    };
+    return childScript;
+  }
+}

--- a/packages/extension-chrome/src/services/ownership.ts
+++ b/packages/extension-chrome/src/services/ownership.ts
@@ -33,10 +33,10 @@ export function createOwnershipService(
       let currentGap = 0;
       for (let index = 0; ; index++) {
         const childScript: Script = generateChildScript(keystoreService, false, index);
-        const childScriptHasHistory = await backend.hasHistory(childScript);
+        const childScriptHasHistory = await backend.hasHistory({ lock: childScript });
         // detect if there is a corresponding change address used also.
         const changeScript: Script = generateChildScript(keystoreService, true, index);
-        const changeScriptHasHistory = await backend.hasHistory(changeScript);
+        const changeScriptHasHistory = await backend.hasHistory({ lock: changeScript });
         changeScriptHasHistory && changeScripts.push(changeScript);
         if (childScriptHasHistory) {
           externalScripts.push(childScript);
@@ -61,7 +61,7 @@ export function createOwnershipService(
       errors.unimplemented();
     },
     signData: async (payload: SignDataPayload) => {
-      const addressInfo = addressStorageService.getAddressInfoByLock(payload.lock);
+      const addressInfo = addressStorageService.getAddressInfoByLock({ lock: payload.lock });
       if (!addressInfo) {
         errors.throwError('address not found');
       }

--- a/packages/extension-chrome/src/services/ownership.ts
+++ b/packages/extension-chrome/src/services/ownership.ts
@@ -1,4 +1,4 @@
-import { DefaultAddressStorage } from './backend/addressStorage';
+import { AddressStorage } from './backend/addressStorage';
 import { Script } from '@ckb-lumos/base';
 import { Keychain } from '@ckb-lumos/hd';
 import { publicKeyToBlake160, signRecoverable } from '@ckb-lumos/hd/lib/key';
@@ -11,7 +11,11 @@ import { hexify } from '@ckb-lumos/codec/lib/bytes';
 
 const MAX_ADDRESS_GAP = 20;
 
-export function createOwnershipService(keychain: Keychain, backend: Backend): OwnershipService {
+export function createOwnershipService(
+  keychain: Keychain,
+  backend: Backend,
+  addressStorageService: AddressStorage,
+): OwnershipService {
   return {
     getLiveCells: () => {
       errors.unimplemented();
@@ -60,8 +64,6 @@ export function createOwnershipService(keychain: Keychain, backend: Backend): Ow
       errors.unimplemented();
     },
     signData: (payload: SignDataPayload) => {
-      // TODO addressStorageService should be injected here.
-      const addressStorageService = new DefaultAddressStorage(backend, [], [], []);
       const addressInfo = addressStorageService.getAddressInfoByLock(payload.lock);
       if (!addressInfo) {
         errors.throwError('address not found');

--- a/packages/extension-chrome/src/services/ownership.ts
+++ b/packages/extension-chrome/src/services/ownership.ts
@@ -63,14 +63,15 @@ export function createOwnershipService(
     signTransaction: () => {
       errors.unimplemented();
     },
-    signData: (payload: SignDataPayload) => {
+    signData: async (payload: SignDataPayload) => {
+      await addressStorageService.updateUnusedAddresses(keychain);
       const addressInfo = addressStorageService.getAddressInfoByLock(payload.lock);
       if (!addressInfo) {
         errors.throwError('address not found');
       }
       const targetKeychain = keychain.derivePath(addressInfo.path);
       const signature = signRecoverable(hexify(payload.data), hexify(targetKeychain.privateKey));
-      return Promise.resolve(signature);
+      return signature;
     },
   };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,4 @@
 export type { InjectedCkb, CkbProvider } from './injected';
 export type { OwnershipService, NotificationService, KeystoreService, GrantService } from './services';
-export type { GetUsedLocksPayload } from './services/OwnershipService';
 export type { Storage } from './storage';
 export type { Promisable, Paginate, Cursor } from './base';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export type { InjectedCkb, CkbProvider } from './injected';
 export type { OwnershipService, NotificationService, KeystoreService, GrantService } from './services';
+export type { GetUsedLocksPayload } from './services/OwnershipService';
 export type { Storage } from './storage';
 export type { Promisable, Paginate, Cursor } from './base';

--- a/packages/types/src/services/KeystoreService.ts
+++ b/packages/types/src/services/KeystoreService.ts
@@ -24,6 +24,17 @@ export interface KeystoreService {
    * @param payload {@link SignMessagePayload}
    */
   signMessage(payload: SignMessagePayload): Promisable<HexString>;
+
+  /**
+   * get the public key of a child path,
+   *
+   */
+  getChildPubkey(payload: GetChildPubkeyPayload): string;
+}
+
+export interface GetChildPubkeyPayload {
+  change?: boolean;
+  index: number;
 }
 
 interface GetExtendedPublicKeyPayload {

--- a/packages/types/src/services/OwnershipService.ts
+++ b/packages/types/src/services/OwnershipService.ts
@@ -33,7 +33,7 @@ interface GetUnusedLocksPayload {
   change?: boolean;
 }
 
-interface GetUsedLocksPayload extends GetUnusedLocksPayload, GetPaginateItemsPayload {}
+export interface GetUsedLocksPayload extends GetUnusedLocksPayload, GetPaginateItemsPayload {}
 
 interface SignTransactionPayload {
   tx: Transaction;


### PR DESCRIPTION
## Description

This pr implements `getUsedLocks` of `ownershipService`.

`getUsedLocks` should scan user locks according to the logic descripbed in bip-44:
https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery

## Usage

To use the ownership service, a `NotificationService`, `KeystoreService`, `Backend` and `AddressStorageService` should be created to query transactions on the CKB chain.

```typescript
const service = createOwnershipService(notificationService, keystoreService, backend, addressStorageService);
const usedLocks = await service.getUsedLocks({});
```
The `backend` service should at least provide `hasHistory` to count transactions of given lock script on the CKB chain.

```typescript
const backend = BackendProvider.getDefaultBackend();
```

## Test

- [x] Unit test based on mocked services