### PR TITLE
feat: supported keystore service

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   projects: ['<rootDir>/packages/*'],
+  coveragePathIgnorePatterns: ['lumos/*', 'lib'],
+  testPathIgnorePatterns: ['lumos/*'],
 };

--- a/packages/extension-chrome/__tests__/services/keystore.ts
+++ b/packages/extension-chrome/__tests__/services/keystore.ts
@@ -1,6 +1,6 @@
 import type { KeystoreService, Storage } from '@nexus-wallet/types';
 import { createInMemoryStorage } from '../../src/services/storage';
-import { assertDerivationPath, createKeyStoreService } from '../../src/services/keystore';
+import { assertDerivationPath, createKeystoreService } from '../../src/services/keystore';
 import hd from '@ckb-lumos/hd';
 
 describe('assertDerivationPath', () => {
@@ -55,10 +55,10 @@ let service: KeystoreService;
 
 beforeEach(async () => {
   storage = createInMemoryStorage();
-  service = createKeyStoreService({ storage });
+  service = createKeystoreService({ storage });
 
   const parent = fixture.derived[0];
-  await service.initKeyStore({
+  await service.initKeystore({
     mnemonic: fixture.mnemonic,
     // parent path
     paths: [parent.path],
@@ -72,7 +72,7 @@ afterEach(() => {
 
 test('re-initialize should throw error', async () => {
   await expect(
-    service.initKeyStore({
+    service.initKeystore({
       mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
       paths: [`m/44'/309'/0'/0`],
       password: '123456',

--- a/packages/extension-chrome/__tests__/services/keystore.ts
+++ b/packages/extension-chrome/__tests__/services/keystore.ts
@@ -1,0 +1,112 @@
+import type { KeystoreService, Storage } from '@nexus-wallet/types';
+import { createInMemoryStorage } from '../../src/services/storage';
+import { assertDerivationPath, createKeyStoreService } from '../../src/services/keystore';
+import hd from '@ckb-lumos/hd';
+
+describe('assertDerivationPath', () => {
+  test('normal', () => {
+    expect(() => assertDerivationPath(`m/44'/309'/0'/0/0`)).not.toThrow();
+  });
+
+  test('incorrect path', () => {
+    expect(() => assertDerivationPath(`m/incorrect/path`)).toThrow();
+  });
+
+  test('incorrect options', () => {
+    expect(() => assertDerivationPath(`m/44'/309'/0'/0/0`, { hardened: true, nonhardened: true })).toThrow();
+  });
+
+  test('hardened', () => {
+    expect(() => assertDerivationPath(`m/44'/309'/0'`, { hardened: true })).not.toThrow();
+    expect(() => assertDerivationPath(`m/44'/309'/0'/0`, { hardened: true })).toThrow();
+  });
+
+  test('nonhardened', () => {
+    expect(() => assertDerivationPath(`m/44'/309'/0'`, { nonhardened: true })).toThrow();
+    expect(() => assertDerivationPath(`m/44'/309'/0'/0`, { nonhardened: true })).not.toThrow();
+  });
+});
+
+//https://github.com/nervosnetwork/neuron/blob/80b58022a3857ba36494e6dad90ac21ef32caae8/packages/neuron-wallet/tests/models/keys/keychain.test.ts#L154-L193
+const fixture = {
+  mnemonic: 'tank planet champion pottery together intact quick police asset flower sudden question',
+  privateKey: '0x37d25afe073a6ba17badc2df8e91fc0de59ed88bcad6b9a0c2210f325fafca61',
+  publicKey: '0x020720a7a11a9ac4f0330e2b9537f594388ea4f1cd660301f40b5a70e0bc231065',
+  chainCode: '0x5f772d1e3cfee5821911aefa5e8f79d20d4cf6678378d744efd08b66b2633b80',
+  derived: [
+    // parent
+    {
+      path: `m/44'/309'/0'/0`,
+      privateKey: '0x047fae4f38b3204f93a6b39d6dbcfbf5901f2b09f6afec21cbef6033d01801f1',
+      publicKey: '0x03d0b797208fa010610f03e86776d15fec29de0b7b40b7a0baad63a8667385c2d6',
+    },
+    // child, one more `/0` then parent
+    {
+      path: `m/44'/309'/0'/0/0`,
+      privateKey: '0x848422863825f69e66dc7f48a3302459ec845395370c23578817456ad6b04b14',
+      publicKey: '0x034dc074f2663d73aedd36f5fc2d1a1e4ec846a4dffa62d8d8bae8a4d6fffdf2b0',
+    },
+  ],
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let storage: Storage<any>;
+let service: KeystoreService;
+
+beforeEach(async () => {
+  storage = createInMemoryStorage();
+  service = createKeyStoreService({ storage });
+
+  const parent = fixture.derived[0];
+  await service.initKeyStore({
+    mnemonic: fixture.mnemonic,
+    // parent path
+    paths: [parent.path],
+    password: '123456',
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('re-initialize should throw error', async () => {
+  await expect(
+    service.initKeyStore({
+      mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+      paths: [`m/44'/309'/0'/0`],
+      password: '123456',
+    }),
+  ).rejects.toThrow();
+});
+
+describe('getExtendedPublicKey', () => {
+  test('normal', async () => {
+    const child = fixture.derived[1];
+    const childPublicKey0 = await service.getExtendedPublicKey({ path: child.path });
+
+    expect(childPublicKey0).toBe(child.publicKey);
+  });
+});
+
+describe('signMessage', () => {
+  test('normal', async () => {
+    const mockedMessage = '0x00';
+    const mockedSignature = '0x01';
+
+    const mockedSign = jest.spyOn(hd.key, 'signRecoverable');
+    mockedSign.mockReturnValueOnce(mockedSignature);
+
+    const child = fixture.derived[1];
+    expect(await service.signMessage({ path: child.path, message: mockedMessage, password: '123456' }));
+
+    expect(mockedSign.mock.calls[0][0]).toBe(mockedMessage);
+    expect(mockedSign.mock.calls[0][1]).toBe(child.privateKey);
+  });
+
+  test('incorrect password', async () => {
+    await expect(
+      service.signMessage({ path: `m/44'/309'/0'/0/0`, message: '0x00', password: 'incorrect password' }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/extension-chrome/__tests__/services/keystore.ts
+++ b/packages/extension-chrome/__tests__/services/keystore.ts
@@ -110,3 +110,10 @@ describe('signMessage', () => {
     ).rejects.toThrow();
   });
 });
+
+describe('reset', () => {
+  test('normal', async () => {
+    await service.reset();
+    await expect(Promise.resolve(storage.getItem('keystore'))).resolves.toBeFalsy();
+  });
+});

--- a/packages/extension-chrome/src/services/keystore/index.ts
+++ b/packages/extension-chrome/src/services/keystore/index.ts
@@ -1,0 +1,1 @@
+export { createKeyStoreService, assertDerivationPath } from './keystore';

--- a/packages/extension-chrome/src/services/keystore/index.ts
+++ b/packages/extension-chrome/src/services/keystore/index.ts
@@ -1,1 +1,1 @@
-export { createKeyStoreService, assertDerivationPath } from './keystore';
+export { createKeystoreService, assertDerivationPath } from './keystore';

--- a/packages/extension-chrome/src/services/keystore/keystore.ts
+++ b/packages/extension-chrome/src/services/keystore/keystore.ts
@@ -24,8 +24,8 @@ export function createKeyStoreService(config: { storage: Storage<KeystoreData> }
     return keystoreData;
   }
 
-  const keystoreService = {
-    async initKeyStore(payload: InitKeyStorePayload): Promise<void> {
+  const keystoreService: KeystoreService = {
+    initKeyStore: async (payload: InitKeyStorePayload): Promise<void> => {
       const isInitialized = await keystoreService.hasInitialized();
 
       if (isInitialized) errors.throwError('Keystore has been initialized');
@@ -53,7 +53,7 @@ export function createKeyStoreService(config: { storage: Storage<KeystoreData> }
       storage.setItem('keystore', { publicInfos, wss });
     },
 
-    async getExtendedPublicKey(payload: GetExtendedPublicKeyPayload): Promise<string> {
+    getExtendedPublicKey: async (payload: GetExtendedPublicKeyPayload): Promise<string> => {
       const { path } = payload;
 
       assertDerivationPath(path);
@@ -81,9 +81,10 @@ export function createKeyStoreService(config: { storage: Storage<KeystoreData> }
       return bytes.hexify(extendedPublicKey.derivePath(childPath).publicKey);
     },
 
-    hasInitialized(): Promisable<boolean> {
+    hasInitialized: (): Promisable<boolean> => {
       return storage.hasItem('keystore');
     },
+
     signMessage: async (payload: SignMessagePayload): Promise<HexString> => {
       const keystoreData = await resolveKeystoreData();
 
@@ -94,6 +95,10 @@ export function createKeyStoreService(config: { storage: Storage<KeystoreData> }
         bytes.hexify(payload.message),
         extendedPrivateKey.privateKeyInfoByPath(payload.path).privateKey,
       );
+    },
+
+    reset: async () => {
+      await storage.removeItem('keystore');
     },
   };
 

--- a/packages/extension-chrome/src/services/keystore/keystore.ts
+++ b/packages/extension-chrome/src/services/keystore/keystore.ts
@@ -2,7 +2,7 @@ import type { HexString } from '@ckb-lumos/lumos';
 import type { KeystoreService, Promisable, Storage } from '@nexus-wallet/types';
 import type {
   GetExtendedPublicKeyPayload,
-  InitKeyStorePayload,
+  InitKeystorePayload,
   SignMessagePayload,
   NonHardenedPath,
 } from '@nexus-wallet/types/lib/services/KeystoreService';
@@ -11,7 +11,7 @@ import { hd } from '@ckb-lumos/lumos';
 import { bytes } from '@ckb-lumos/codec';
 import { key, Keystore } from '@ckb-lumos/hd';
 
-export function createKeyStoreService(config: { storage: Storage<KeystoreData> }): KeystoreService {
+export function createKeystoreService(config: { storage: Storage<KeystoreData> }): KeystoreService {
   const { storage } = config;
 
   async function resolveKeystoreData(): Promise<KeystoreData['keystore']> {
@@ -25,7 +25,7 @@ export function createKeyStoreService(config: { storage: Storage<KeystoreData> }
   }
 
   const keystoreService: KeystoreService = {
-    initKeyStore: async (payload: InitKeyStorePayload): Promise<void> => {
+    initKeystore: async (payload: InitKeystorePayload): Promise<void> => {
       const isInitialized = await keystoreService.hasInitialized();
 
       if (isInitialized) errors.throwError('Keystore has been initialized');

--- a/packages/extension-chrome/src/services/keystore/keystore.ts
+++ b/packages/extension-chrome/src/services/keystore/keystore.ts
@@ -1,0 +1,143 @@
+import type { HexString } from '@ckb-lumos/lumos';
+import type { KeystoreService, Promisable, Storage } from '@nexus-wallet/types';
+import type {
+  GetExtendedPublicKeyPayload,
+  InitKeyStorePayload,
+  SignMessagePayload,
+  NonHardenedPath,
+} from '@nexus-wallet/types/lib/services/KeystoreService';
+import { asserts, errors, resolveProvider } from '@nexus-wallet/utils';
+import { hd } from '@ckb-lumos/lumos';
+import { bytes } from '@ckb-lumos/codec';
+import { key, Keystore } from '@ckb-lumos/hd';
+
+export function createKeyStoreService(config: { storage: Storage<KeystoreData> }): KeystoreService {
+  const { storage } = config;
+
+  async function resolveKeystoreData(): Promise<KeystoreData['keystore']> {
+    const keystoreData = await storage.getItem('keystore');
+
+    if (!keystoreData) {
+      errors.throwError('Keystore not initialized');
+    }
+
+    return keystoreData;
+  }
+
+  const keystoreService = {
+    async initKeyStore(payload: InitKeyStorePayload): Promise<void> {
+      const isInitialized = await keystoreService.hasInitialized();
+
+      if (isInitialized) errors.throwError('Keystore has been initialized');
+
+      const { mnemonic: inputMnemonic, password, paths } = payload;
+
+      paths.forEach((path) => {
+        assertDerivationPath(path, { hardened: false });
+      });
+
+      const seed = await hd.mnemonic.mnemonicToSeed(inputMnemonic);
+      const keychain = hd.Keychain.fromSeed(seed);
+
+      const publicInfos = paths.reduce((result, path) => {
+        const childChain = keychain.derivePath(path);
+        return result.concat({
+          path,
+          publicKey: bytes.hexify(childChain.publicKey),
+          chainCode: bytes.hexify(childChain.chainCode),
+        });
+      }, [] as PublicInfo[]);
+
+      const wss = hd.Keystore.create(hd.ExtendedPrivateKey.fromSeed(seed), password).toJson();
+
+      storage.setItem('keystore', { publicInfos, wss });
+    },
+
+    async getExtendedPublicKey(payload: GetExtendedPublicKeyPayload): Promise<string> {
+      const { path } = payload;
+
+      assertDerivationPath(path);
+
+      const keystoreData = await resolveKeystoreData();
+
+      const parent = keystoreData.publicInfos.find((publicInfo) => path.includes(publicInfo.path));
+      asserts.asserts(parent, `Extended public key not found for path: %s`, path);
+
+      if (parent.path === path) return parent.publicKey;
+
+      // TODO: update lumos/hd to support BytesLike param instead of Buffer
+      const extendedPublicKey = hd.Keychain.fromPublicKey(
+        Buffer.from(bytes.bytify(parent.publicKey)),
+        Buffer.from(bytes.bytify(parent.chainCode)),
+        parent.path,
+      );
+
+      // the child path is the path after the parent path
+      // e.g. parent path: m/44'/309'/0'/0
+      //      child path:  m/44'/309'/0'/0/0
+      // to derive child public key, we can use the API parent.derivePath('0/0')
+      const childPath = path.replace(parent.path + '/', '');
+
+      return bytes.hexify(extendedPublicKey.derivePath(childPath).publicKey);
+    },
+
+    hasInitialized(): Promisable<boolean> {
+      return storage.hasItem('keystore');
+    },
+    signMessage: async (payload: SignMessagePayload): Promise<HexString> => {
+      const keystoreData = await resolveKeystoreData();
+
+      const keystore = Keystore.fromJson(keystoreData.wss);
+      const extendedPrivateKey = keystore.extendedPrivateKey(await resolveProvider(payload.password));
+
+      return key.signRecoverable(
+        bytes.hexify(payload.message),
+        extendedPrivateKey.privateKeyInfoByPath(payload.path).privateKey,
+      );
+    },
+  };
+
+  return keystoreService;
+}
+
+export function assertDerivationPath(path: string, options: { hardened?: boolean; nonhardened?: boolean } = {}): void {
+  if (options.hardened && options.nonhardened) {
+    errors.throwError(`"hardened" or "nonhardened" can only be one of them in options`);
+  }
+
+  if (!isValidDerivationPath(path)) {
+    errors.throwError(`Invalid derivation path: %s`, path);
+  }
+
+  if (options.hardened && !isHardenedPath(path)) {
+    errors.throwError(`Derivation path must be hardened: %s`, path);
+  }
+
+  if (options.nonhardened && isHardenedPath(path)) {
+    errors.throwError(`Derivation path must be non-hardened: %s`, path);
+  }
+}
+
+function isHardenedPath(path: string): boolean {
+  return path.endsWith("'");
+}
+
+const DERIVATION_PATH_REGEX = /^m(\/\d+'?)*$/;
+
+function isValidDerivationPath(path: string): boolean {
+  return path.match(DERIVATION_PATH_REGEX) !== null;
+}
+
+interface KeystoreData {
+  keystore: {
+    publicInfos: PublicInfo[];
+    // Web3 Secret Storage, it is a string in JSON format
+    wss: string;
+  };
+}
+
+interface PublicInfo {
+  path: NonHardenedPath;
+  chainCode: HexString;
+  publicKey: HexString;
+}

--- a/packages/types/src/services/KeystoreService.ts
+++ b/packages/types/src/services/KeystoreService.ts
@@ -9,6 +9,10 @@ export interface KeystoreService {
    */
   hasInitialized(): Promisable<boolean>;
 
+  /**
+   * Only non-hardened path can be used to generate extended public key
+   * @param payload
+   */
   initKeyStore(payload: InitKeyStorePayload): Promisable<void>;
 
   /**
@@ -17,16 +21,21 @@ export interface KeystoreService {
    * the password will be required to derive the extended public key
    * @param payload
    */
-  getExtendedPublicKey(payload: GetExtendedPublicKeyPayload): Promisable<string>;
+  getExtendedPublicKey(payload: GetExtendedPublicKeyPayload): Promisable<HexString>;
 
   /**
    *
    * @param payload {@link SignMessagePayload}
    */
   signMessage(payload: SignMessagePayload): Promisable<HexString>;
+
+  /**
+   * clear all data about the keystore, including the mnemonic, extended public keys, etc.
+   */
+  reset(): Promisable<void>;
 }
 
-interface GetExtendedPublicKeyPayload {
+export interface GetExtendedPublicKeyPayload {
   path: HardenedPath | NonHardenedPath;
   password?: PasswordProvider;
 }
@@ -72,9 +81,9 @@ export interface SignMessagePayload {
 /**
  * checkout BIP-32 learn more about the {@link https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#extended-keys hardened key}
  */
-type HardenedPath = string;
+export type HardenedPath = string;
 /**
  * checkout BIP-32 learn more about the {@link https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#extended-keys non-hardened key}
  */
-type NonHardenedPath = string;
-type PasswordProvider = Provider<string>;
+export type NonHardenedPath = string;
+export type PasswordProvider = Provider<string>;

--- a/packages/types/src/services/KeystoreService.ts
+++ b/packages/types/src/services/KeystoreService.ts
@@ -10,7 +10,7 @@ export interface KeystoreService {
   hasInitialized(): Promisable<boolean>;
 
   /**
-   * Only non-hardened path can be used to generate extended public key
+   * initialize the keystore
    * @param payload
    */
   initKeystore(payload: InitKeystorePayload): Promisable<void>;
@@ -55,10 +55,18 @@ export interface InitKeystorePayload {
   mnemonic: string;
 
   /**
-   * non-hardened derivation path,
-   * the corresponding public key will be stored in plain text,
-   * for example, the BIP-44 path `m / 44'/ 309'/ 0'/ 0 / 0` will store the public key of
-   * `m / 44' / 309' / 0' / 0` (external) and `m/44'/ 309'/ 0'/ 1` (internal) in plain text
+   * must be an array of non-hardened derivation path, it is used to derive the extended keys.
+   * @example
+   * ```
+   * // the BIP44 path is `m / purpose' / coin_type' / account' / change / address_index`
+   * // to initialize a BIP44 keystore, we need to provide two paths end with `change`,
+   * // they also act as the parent paths. Once the parent paths are provided, the keystore
+   * // will be able to derive associated child keys
+   * const bip44ParentPaths = [
+   *   `m/44'/309'/0'/0`, // to derive external(change: 0) addresses
+   *   `m/44'/309'/0'/1`, // to derive internal(change: 1) addresses
+   * ];
+   * ```
    */
   paths: NonHardenedPath[];
 }

--- a/packages/types/src/services/KeystoreService.ts
+++ b/packages/types/src/services/KeystoreService.ts
@@ -13,7 +13,7 @@ export interface KeystoreService {
    * Only non-hardened path can be used to generate extended public key
    * @param payload
    */
-  initKeyStore(payload: InitKeyStorePayload): Promisable<void>;
+  initKeystore(payload: InitKeystorePayload): Promisable<void>;
 
   /**
    * get an extended public key by a derivation path,
@@ -44,7 +44,7 @@ export interface GetExtendedPublicKeyPayload {
  * A {@link https://ethereum.org/en/developers/docs/data-structures-and-encoding/web3-secret-storage/ Web3 secret storage} wrapper,
  * to interact with the keystore
  */
-export interface InitKeyStorePayload {
+export interface InitKeystorePayload {
   /**
    * password to encrypt the keystore
    */

--- a/packages/types/src/services/OwnershipService.ts
+++ b/packages/types/src/services/OwnershipService.ts
@@ -1,6 +1,6 @@
-import type { BytesLike } from '@ckb-lumos/codec';
-import type { Cell, Script, Transaction } from '@ckb-lumos/lumos';
 import type { Bytes, Paginate } from '../base';
+import type { Cell, Script, Transaction } from '@ckb-lumos/lumos';
+import type { BytesLike } from '@ckb-lumos/codec';
 
 export interface OwnershipService {
   getLiveCells(payload?: GetPaginateItemsPayload): Promise<Paginate<Cell>>;

--- a/packages/utils/__tests__/asserts.ts
+++ b/packages/utils/__tests__/asserts.ts
@@ -7,4 +7,6 @@ it('utils#asserts', () => {
   expect(() => asserts.nonFalsy(null)).toThrow();
 
   expect(() => asserts.nonFalsy(1)).not.toThrow();
+
+  expect(() => asserts.asserts(1 + 1 === 3)).toThrow();
 });

--- a/packages/utils/__tests__/error.ts
+++ b/packages/utils/__tests__/error.ts
@@ -1,6 +1,19 @@
 import { errors } from '../src';
 
-it('utils#error throw', () => {
+describe('errors', () => {
+  test('plain message', () => {
+    expect(() => errors.throwError('plain message')).toThrow(/plain message/);
+  });
+
+  test('format error message', () => {
+    expect(() => errors.throwError('error string: %s', 'message')).toThrow(/error string: message /);
+    expect(() => errors.throwError('error buffer: %s', Buffer.from([0, 1, 2]))).toThrow(/error buffer: 0x000102/);
+    expect(() => errors.throwError('error number: %s', 1)).toThrow(/error number: 1/);
+    expect(() => errors.throwError('error object: %s', { key: 'value' })).toThrow(/error object: {"key":"value"}/);
+  });
+});
+
+test('utils#error throw', () => {
   expect(() => errors.throwError()).toThrow();
   expect(() => errors.unimplemented()).toThrow(/Unimplemented/);
 });

--- a/packages/utils/__tests__/internal.ts
+++ b/packages/utils/__tests__/internal.ts
@@ -1,0 +1,10 @@
+import { resolveProvider } from '../src';
+
+test('resolveProvider', async () => {
+  const password = '123456';
+
+  // sync provider
+  expect(resolveProvider(password)).toBe(password);
+  // async provider
+  await expect(resolveProvider(() => Promise.resolve(password))).resolves.toBe(password);
+});

--- a/packages/utils/src/asserts.ts
+++ b/packages/utils/src/asserts.ts
@@ -10,6 +10,6 @@ export function nonFalsy(x: unknown): asserts x {
   if (!x) throwError('cannot be falsy');
 }
 
-export function asserts(condition: unknown, message?: string): asserts condition {
-  if (!condition) throwError(message || 'Assertion failed');
+export function asserts(condition: unknown, message?: string, ...args: unknown[]): asserts condition {
+  if (!condition) throwError(message || 'Assertion failed', args);
 }

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -1,11 +1,26 @@
 import { LIB_VERSION } from './version';
+import { bytes, BytesLike } from '@ckb-lumos/codec';
 
-export function makeError(message = 'Unknown error'): Error {
-  return new Error(`[NexusWallet]: ${message}  (version=${LIB_VERSION})`);
+function formatArgs(arg: unknown): string {
+  if (typeof arg === 'string') {
+    return arg;
+  }
+
+  try {
+    return bytes.hexify(bytes.bytify(arg as BytesLike));
+  } catch {
+    return JSON.stringify(arg);
+  }
 }
 
-export function throwError(message?: string): never {
-  throw makeError(message);
+export function makeError(message = 'Unknown error', ...args: unknown[]): Error {
+  let i = 0;
+  const formatted = message.replace(/%s/g, () => formatArgs(args[i++]));
+  return new Error(`[NexusWallet]: ${formatted}  (version=${LIB_VERSION})`);
+}
+
+export function throwError(message?: string, ...args: unknown[]): never {
+  throw makeError(message, ...args);
 }
 
 export function unimplemented(): never {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
 export { LIB_VERSION } from './version';
 export * as errors from './error';
 export * as asserts from './asserts';
+export { resolveProvider } from './internal';

--- a/packages/utils/src/internal.ts
+++ b/packages/utils/src/internal.ts
@@ -1,0 +1,6 @@
+import type { Provider } from '@nexus-wallet/types/lib/services/common';
+import type { Promisable } from '@nexus-wallet/types';
+
+export function resolveProvider<T>(provider: Provider<T>): Promisable<T> {
+  return provider instanceof Function ? provider() : provider;
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
+  "extends": ["config:base"],
+  "ignoreDeps": [
+    "@ckb-lumos/base",
+    "@ckb-lumos/bi",
+    "@ckb-lumos/ckb-indexer",
+    "@ckb-lumos/codec",
+    "@ckb-lumos/common-script",
+    "@ckb-lumos/config-manager",
+    "@ckb-lumos/debugger",
+    "@ckb-lumos/experiment-tx-assembler",
+    "@ckb-lumos/hd",
+    "@ckb-lumos/hd-cache",
+    "@ckb-lumos/helpers",
+    "@ckb-lumos/light-client",
+    "@ckb-lumos/lumos",
+    "@ckb-lumos/molecule",
+    "@ckb-lumos/rpc",
+    "@ckb-lumos/testkit",
+    "@ckb-lumos/toolkit",
+    "@ckb-lumos/transaction-manager"
   ]
 }


### PR DESCRIPTION
this PR implemented `KeystoreService`, we can find use cases in [tests](https://github.com/ckb-js/nexus/blob/1ed6a1050c961c3b69adadecf4174fc2e624f541/packages/extension-chrome/__tests__/services/keystore.ts)

To merge this PR, we should first

- [x] review and merge https://github.com/ckb-js/nexus/pull/44
- [x] change this PR target to `main` 