### PR TITLE
feat: session messenger

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           git diff --exit-code
 
       - name: Run unit test
-        run: npx jest --coverage
+        run: npx jest --coverage --verbose
 
       - uses: codecov/codecov-action@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,9 +1055,11 @@
       },
       "devDependencies": {
         "@ckb-lumos/testkit": "0.20.0-alpha.1",
+        "@types/lodash.uniqby": "^4.7.7",
         "@types/request": "^2.48.8",
         "@types/sinon": "^10.0.6",
         "find-process": "^1.4.7",
+        "lodash.uniqby": "^4.7.0",
         "request": "^2.88.2",
         "sinon": "^12.0.1",
         "ts-node": "^10.4.0"
@@ -1335,6 +1337,7 @@
         "@ckb-lumos/bi": "0.20.0-alpha.1",
         "bn.js": "^5.1.3",
         "elliptic": "^6.5.4",
+        "scrypt-js": "^3.0.1",
         "sha3": "^2.1.3",
         "uuid": "^8.3.0"
       },
@@ -9320,6 +9323,15 @@
       "version": "4.3.7",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.uniqby": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqby/-/lodash.uniqby-4.7.7.tgz",
+      "integrity": "sha512-sv2g6vkCIvEUsK5/Vq17haoZaisfj2EWW8mP7QWlnKi6dByoNmeuHDDXHR7sabuDqwO4gvU7ModIL22MmnOocg==",
+      "dev": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -21812,6 +21824,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "dev": true,
@@ -25990,6 +26008,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
@@ -31324,11 +31347,13 @@
         "@ckb-lumos/rpc": "0.20.0-alpha.1",
         "@ckb-lumos/testkit": "0.20.0-alpha.1",
         "@ckb-lumos/toolkit": "0.20.0-alpha.1",
+        "@types/lodash.uniqby": "^4.7.7",
         "@types/request": "^2.48.8",
         "@types/sinon": "^10.0.6",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
         "find-process": "^1.4.7",
+        "lodash.uniqby": "^4.7.0",
         "request": "^2.88.2",
         "sinon": "^12.0.1",
         "ts-node": "^10.4.0"
@@ -31513,6 +31538,7 @@
         "@types/uuid": "^8.3.0",
         "bn.js": "^5.1.3",
         "elliptic": "^6.5.4",
+        "scrypt-js": "^3.0.1",
         "sha3": "^2.1.3",
         "uuid": "^8.3.0"
       }
@@ -35025,6 +35051,15 @@
     },
     "@types/lodash.times": {
       "version": "4.3.7",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.uniqby": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqby/-/lodash.uniqby-4.7.7.tgz",
+      "integrity": "sha512-sv2g6vkCIvEUsK5/Vq17haoZaisfj2EWW8mP7QWlnKi6dByoNmeuHDDXHR7sabuDqwO4gvU7ModIL22MmnOocg==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -43300,6 +43335,12 @@
       "version": "4.4.2",
       "dev": true
     },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true
+    },
     "log-symbols": {
       "version": "4.1.0",
       "dev": true,
@@ -46520,6 +46561,11 @@
     },
     "screenfull": {
       "version": "5.2.0"
+    },
+    "scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "seek-bzip": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "build": "run-s build:lumos build:nexus",
     "build:nexus": "npm run build --workspace=@nexus-wallet/types --workspace=@nexus-wallet/utils",
     "build:lumos": "cd lumos && npm run build",
-    "test": "jest"
+    "test": "jest",
+    "start": "npm run start -w @nexus-wallet/extension-chrome"
   },
   "repository": {
     "type": "git",

--- a/packages/extension-chrome/__tests__/messaging/session.ts
+++ b/packages/extension-chrome/__tests__/messaging/session.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from 'events';
+import { Call, createSessionMessenger, MessengerAdapter } from '../../src/messaging/session';
+
+// an adapter based on EventEmitter
+let adapter: MessengerAdapter;
+let ee: EventEmitter;
+
+beforeEach(() => {
+  ee = new EventEmitter();
+
+  adapter = {
+    send: (message) => ee.emit('message', message),
+    receive: (handler) => ee.addListener('message', handler),
+    dispose: (handler) => ee.removeListener('message', handler),
+  };
+});
+
+test('ping-pong example', async () => {
+  type Map = { ping: Call<void, 'pong'> };
+
+  const server = createSessionMessenger<Map>({ adapter });
+  server.register('ping', () => 'pong');
+  // there should be a receiver in server
+  expect(ee.listeners('message')).toHaveLength(1);
+
+  const client = createSessionMessenger<Map>({ adapter, sessionId: server.sessionId() });
+  await expect(client.send('ping')).resolves.toBe('pong');
+
+  // there should be no receiver in server after calling destroy()
+  server.destroy();
+  expect(ee.listeners('message')).toHaveLength(0);
+});
+
+it('should ignore when received unknown message in a server', async () => {
+  const messenger = createSessionMessenger({ adapter });
+
+  const emit = jest.spyOn(ee, 'emit');
+
+  messenger.register('ping', () => 'pong');
+  await messenger.send('ping');
+
+  // messenger will emit a 'ping' request to itself
+  // then it will receive the ping and emit a pong response
+  // so the emit function will be called twice
+  expect(emit.mock.calls).toHaveLength(2);
+
+  // no await here because unknown message will never be resolved
+  void messenger.send('unknown message');
+  // wait for 100ms to make sure the unknown message is sent
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  // messenger will post a 'unknown message' message to itself
+  // then it will receive the unknown message and do nothing
+  expect(emit.mock.calls).toHaveLength(3);
+});
+
+it('should should ignore when received message from different messages in a server', async () => {
+  const server = createSessionMessenger({ adapter });
+  server.register('ping', () => 'pong');
+
+  const client = createSessionMessenger({ adapter, sessionId: 'another-session-id' });
+
+  const emit = jest.spyOn(ee, 'emit');
+
+  // no await here because unknown message will never be resolved
+  void client.send('ping'); // emit time = 1
+  expect(emit.mock.calls).toHaveLength(1);
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(emit.mock.calls).toHaveLength(1);
+});
+
+it('should throw an error in client when server handler throws an error', async () => {
+  const server = createSessionMessenger({ adapter });
+  server.register('ping', () => {
+    throw new Error('server error');
+  });
+
+  const client = createSessionMessenger({ adapter, sessionId: server.sessionId() });
+  await expect(client.send('ping')).rejects.not.toBeFalsy();
+});
+
+it('should works with more than one client', async () => {
+  const server = createSessionMessenger({ adapter });
+  server.register('ping', () => 'pong');
+
+  const client1 = createSessionMessenger({ adapter, sessionId: server.sessionId() });
+  const client2 = createSessionMessenger({ adapter, sessionId: server.sessionId() });
+
+  await expect(client1.send('ping')).resolves.toBe('pong');
+  await expect(client2.send('ping')).resolves.toBe('pong');
+});

--- a/packages/extension-chrome/__tests__/services/keystore.ts
+++ b/packages/extension-chrome/__tests__/services/keystore.ts
@@ -49,48 +49,46 @@ const fixture = {
   ],
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let storage: Storage<any>;
-let service: KeystoreService;
+describe('KeystoreService', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let storage: Storage<any>;
+  let service: KeystoreService;
 
-beforeEach(async () => {
-  storage = createInMemoryStorage();
-  service = createKeystoreService({ storage });
+  beforeAll(async () => {
+    storage = createInMemoryStorage();
+    service = createKeystoreService({ storage });
 
-  const parent = fixture.derived[0];
-  await service.initKeystore({
-    mnemonic: fixture.mnemonic,
-    // parent path
-    paths: [parent.path],
-    password: '123456',
-  });
-});
-
-afterEach(() => {
-  jest.clearAllMocks();
-});
-
-test('re-initialize should throw error', async () => {
-  await expect(
-    service.initKeystore({
-      mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-      paths: [`m/44'/309'/0'/0`],
+    const parent = fixture.derived[0];
+    await service.initKeystore({
+      mnemonic: fixture.mnemonic,
+      // parent path
+      paths: [parent.path],
       password: '123456',
-    }),
-  ).rejects.toThrow();
-});
+    });
+  });
 
-describe('getExtendedPublicKey', () => {
-  test('normal', async () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('re-initialize should throw error', async () => {
+    await expect(
+      service.initKeystore({
+        mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        paths: [`m/44'/309'/0'/0`],
+        password: '123456',
+      }),
+    ).rejects.toThrow();
+  });
+
+  test('getExtendedPublicKey should works', async () => {
     const child = fixture.derived[1];
     const childPublicKey0 = await service.getExtendedPublicKey({ path: child.path });
 
     expect(childPublicKey0).toBe(child.publicKey);
   });
-});
 
-describe('signMessage', () => {
-  test('normal', async () => {
+  test('should sign message as expected if the password is correct', async () => {
     const mockedMessage = '0x00';
     const mockedSignature = '0x01';
 
@@ -104,15 +102,13 @@ describe('signMessage', () => {
     expect(mockedSign.mock.calls[0][1]).toBe(child.privateKey);
   });
 
-  test('incorrect password', async () => {
+  test('should throw when the password is incorrect', async () => {
     await expect(
       service.signMessage({ path: `m/44'/309'/0'/0/0`, message: '0x00', password: 'incorrect password' }),
     ).rejects.toThrow();
   });
-});
 
-describe('reset', () => {
-  test('normal', async () => {
+  test('storage should be empty after reset()', async () => {
     await service.reset();
     await expect(Promise.resolve(storage.getItem('keystore'))).resolves.toBeFalsy();
   });

--- a/packages/extension-chrome/src/messaging/adapters.ts
+++ b/packages/extension-chrome/src/messaging/adapters.ts
@@ -1,0 +1,8 @@
+import browser from 'webextension-polyfill';
+import { MessengerAdapter } from './session';
+
+export const browserExtensionAdapter: MessengerAdapter = {
+  send: (message) => browser.runtime.sendMessage(message),
+  receive: (handler) => browser.runtime.onMessage.addListener(handler),
+  dispose: (receiver) => browser.runtime.onMessage.removeListener(receiver),
+};

--- a/packages/extension-chrome/src/messaging/session.ts
+++ b/packages/extension-chrome/src/messaging/session.ts
@@ -1,0 +1,152 @@
+// import browser from 'webextension-polyfill';
+import { nanoid } from 'nanoid';
+import { Promisable } from '@nexus-wallet/types';
+import {
+  createJSONRPCErrorResponse,
+  createJSONRPCRequest,
+  createJSONRPCSuccessResponse,
+  isJSONRPCRequest,
+  isJSONRPCResponse,
+  JSONRPCErrorCode,
+  JSONRPCRequest,
+  JSONRPCResponse,
+} from 'json-rpc-2.0';
+import { asserts } from '@nexus-wallet/utils';
+
+export interface SessionMessenger<Map extends CallMap = CallMap> {
+  sessionId(): string;
+  send<T extends keyof Map>(method: T, params?: CallParam<Map[T]>): Promise<CallResult<Map[T]>>;
+  register<T extends keyof Map>(method: T, handler: (data: CallParam<Map[T]>) => Promisable<CallResult<Map[T]>>): void;
+  destroy(): void;
+}
+
+export type CallMap = Record<string, Call<unknown, unknown>>;
+export type CallParam<T> = T extends Call<infer P, unknown> ? P : never;
+export type CallResult<T> = T extends Call<unknown, infer R> ? R : never;
+
+export interface Call<Param, Result> {
+  param: Param;
+  result: Result;
+}
+
+export const SESSION_MESSAGE_SYMBOL = '__SESSION_MESSAGE_SYMBOL__' as const;
+
+export type SessionMessage = {
+  [SESSION_MESSAGE_SYMBOL]: true;
+  rpc: JSONRPCRequest | JSONRPCResponse;
+};
+
+export interface MessengerAdapter {
+  send(message: SessionMessage): void;
+  receive(handler: MessageReceiver): void;
+  dispose(handler: MessageReceiver): void;
+}
+
+export type MessageReceiver = (message: SessionMessage) => void;
+
+export type CreateSessionMessengerConfig = {
+  sessionId?: string;
+  adapter: MessengerAdapter;
+};
+
+/**
+ * a two-way JSON-RPC 2.0 messenger wrapper for communication between two parties
+ * @param config
+ * @example
+ * ```ts
+ * type Map = {
+ *   ping: Call<void, 'pong'>;
+ * }
+ *
+ * const server = createSessionMessenger<Map>({ adapter });
+ * server.receive('ping', () => 'pong');
+ *
+ * const client = createSessionMessenger<Map>({ adapter, sessionId: server.sessionId() });
+ * await client.send('ping'); // 'pong'
+ * ```
+ */
+export function createSessionMessenger<Map extends CallMap>(
+  config: CreateSessionMessengerConfig,
+): SessionMessenger<Map> {
+  const { sessionId = nanoid(), adapter } = config;
+
+  // a set of JSONRPC request handlers,
+  // used to handle incoming JSONRPC requests
+  // and these handlers will be removed after calling destroy()
+  let handlers = new Set<MessageReceiver>();
+  let reqId = 1;
+
+  const genJsonRpcRequestId = () => `${sessionId}:${reqId++}`;
+  const isCurrentSessionMessage = (message: SessionMessage) => {
+    return typeof message.rpc.id === 'string' && message.rpc.id.startsWith(sessionId);
+  };
+
+  return {
+    sessionId: () => sessionId,
+    send: (type, param) => {
+      const currentReqId = genJsonRpcRequestId();
+
+      const requestMessage = createSessionMessage(createJSONRPCRequest(currentReqId, String(type), param));
+      adapter.send(requestMessage);
+
+      return new Promise((resolve, reject) => {
+        adapter.receive(function handleResponse(unknownMessage) {
+          if (!isSessionMessage(unknownMessage)) {
+            return;
+          }
+
+          const res = unknownMessage.rpc;
+          if (!isJSONRPCResponse(res) || res.id !== currentReqId) return;
+
+          adapter.dispose(handleResponse);
+
+          if (res.error) {
+            reject(res.error);
+          } else {
+            resolve(res.result);
+          }
+        });
+      });
+    },
+    register: (method, handler) => {
+      adapter.receive(async function handleRequest(unknownMessage) {
+        if (!isSessionMessage(unknownMessage)) {
+          return;
+        }
+
+        if (!isCurrentSessionMessage(unknownMessage)) return;
+
+        const req = unknownMessage.rpc;
+        if (!isJSONRPCRequest(req) || req.method !== method) return;
+
+        const res: JSONRPCResponse = await (async () => {
+          asserts.asserts(req.id, `request id is required`);
+          try {
+            return createJSONRPCSuccessResponse(req.id, await handler(req.params));
+          } catch (e) {
+            const errorMessage = e instanceof Error ? e.message : 'Internal Error';
+            return createJSONRPCErrorResponse(req.id, JSONRPCErrorCode.InternalError, errorMessage, e);
+          }
+        })();
+
+        adapter.send(createSessionMessage(res));
+        handlers.add(handleRequest);
+      });
+    },
+    destroy: () => {
+      handlers.forEach((handler) => adapter.dispose(handler));
+    },
+  };
+}
+
+export function createSessionMessage(data: JSONRPCResponse | JSONRPCRequest): SessionMessage {
+  return {
+    [SESSION_MESSAGE_SYMBOL]: true,
+    rpc: data,
+  };
+}
+
+export function isSessionMessage(x: unknown): x is SessionMessage {
+  if (!x || typeof x !== 'object') return false;
+  return SESSION_MESSAGE_SYMBOL in x;
+}

--- a/packages/extension-chrome/src/pages/Notification/containers/Grant.tsx
+++ b/packages/extension-chrome/src/pages/Notification/containers/Grant.tsx
@@ -1,16 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Flex, Heading, Spacer, Text } from '@chakra-ui/react';
-import browser from 'webextension-polyfill';
+import { useSessionMessenger } from '../../hooks/useSessionMessenger';
 
 export const Grant: React.FC = () => {
   const [requesterUrl, setRequesterUrl] = useState<string>();
+  const messenger = useSessionMessenger();
 
   useEffect(() => {
     (async () => {
-      const res = await browser.runtime.sendMessage({ method: 'getRequesterAppInfo' });
+      const res = await messenger.send('session_getRequesterAppInfo');
       setRequesterUrl(res.url);
     })();
-  }, []);
+  }, [messenger]);
 
   if (!requesterUrl) return <h1>waiting...</h1>;
 
@@ -22,7 +23,7 @@ export const Grant: React.FC = () => {
       <Spacer />
       <Button
         onClick={async () => {
-          await browser.runtime.sendMessage({ method: 'userHasEnabledWallet' });
+          await messenger.send('session_approveEnableWallet');
           window.close();
         }}
       >

--- a/packages/extension-chrome/src/pages/Notification/index.tsx
+++ b/packages/extension-chrome/src/pages/Notification/index.tsx
@@ -11,7 +11,7 @@ if (!container) throw new Error('Impossible');
 
 const routes: RouteObject[] = [
   {
-    path: '/grand',
+    path: '/grant',
     element: <Grant />,
   },
   {

--- a/packages/extension-chrome/src/pages/hooks/useSessionMessenger.ts
+++ b/packages/extension-chrome/src/pages/hooks/useSessionMessenger.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { createSessionMessenger, SessionMessenger } from '../../messaging/session';
+import { SessionMethods } from '../../services/notification';
+import { browserExtensionAdapter } from '../../messaging/adapters';
+
+/**
+ * create a SessionMessenger instance for communication with background
+ * @param sessionId
+ */
+export function useSessionMessenger(sessionId?: string): SessionMessenger<SessionMethods> {
+  const [searchParams] = useSearchParams();
+  sessionId = sessionId || searchParams.get('sessionId')!;
+
+  return useMemo(() => createSessionMessenger({ adapter: browserExtensionAdapter, sessionId }), [sessionId]);
+}

--- a/packages/utils/__tests__/internal.ts
+++ b/packages/utils/__tests__/internal.ts
@@ -1,4 +1,4 @@
-import { resolveProvider } from '../src';
+import { formatMessage, resolveProvider } from '../src';
 
 test('resolveProvider', async () => {
   const password = '123456';
@@ -7,4 +7,11 @@ test('resolveProvider', async () => {
   expect(resolveProvider(password)).toBe(password);
   // async provider
   await expect(resolveProvider(() => Promise.resolve(password))).resolves.toBe(password);
+});
+
+test('formatMessage', () => {
+  expect(formatMessage('string: %s', 'message')).toBe(`string: message`);
+  expect(formatMessage('buffer: %s', Buffer.from([0, 1, 2]))).toBe(`buffer: 0x000102`);
+  expect(formatMessage('number: %s', 1)).toBe(`number: 1`);
+  expect(formatMessage('object: %s', { key: 'value' })).toBe(`object: {"key":"value"}`);
 });

--- a/packages/utils/__tests__/internal.ts
+++ b/packages/utils/__tests__/internal.ts
@@ -9,9 +9,16 @@ test('resolveProvider', async () => {
   await expect(resolveProvider(() => Promise.resolve(password))).resolves.toBe(password);
 });
 
-test('formatMessage', () => {
-  expect(formatMessage('string: %s', 'message')).toBe(`string: message`);
-  expect(formatMessage('buffer: %s', Buffer.from([0, 1, 2]))).toBe(`buffer: 0x000102`);
-  expect(formatMessage('number: %s', 1)).toBe(`number: 1`);
-  expect(formatMessage('object: %s', { key: 'value' })).toBe(`object: {"key":"value"}`);
+describe('formatMessage', () => {
+  it('should format message a readable string', () => {
+    expect(formatMessage('string: %s', 'message')).toBe(`string: message`);
+    expect(formatMessage('buffer: %s', Buffer.from([0, 1, 2]))).toBe(`buffer: 0x000102`);
+    expect(formatMessage('number: %s', 1)).toBe(`number: 1`);
+    expect(formatMessage('object: %s', { key: 'value' })).toBe(`object: {"key":"value"}`);
+  });
+
+  it('should append extra arguments to the end of the message', () => {
+    expect(formatMessage('string: %s', 'message', 'extra')).toBe(`string: message extra`);
+    expect(formatMessage('extra buffer', Buffer.from([0, 0, 0]))).toBe('extra buffer 0x000000');
+  });
 });

--- a/packages/utils/__tests__/logger.ts
+++ b/packages/utils/__tests__/logger.ts
@@ -1,0 +1,58 @@
+import { Logger, createLogger, setLogger, setLogLevel } from '../src/logger';
+
+type MockedLog = jest.MockedFunction<(message?: string, ...args: unknown[]) => void>;
+
+let trace: MockedLog;
+let debug: MockedLog;
+let info: MockedLog;
+let warn: MockedLog;
+let error: MockedLog;
+
+let logger: Logger;
+
+beforeEach(() => {
+  trace = jest.fn();
+  debug = jest.fn();
+  info = jest.fn();
+  warn = jest.fn();
+  error = jest.fn();
+
+  setLogger({ trace, debug, info, warn, error });
+
+  logger = createLogger();
+});
+
+describe('logger', () => {
+  it('should logged', () => {
+    logger.info('hello %s', 'world');
+    expect(info.mock.lastCall?.[0]).toMatch(/hello world/);
+  });
+
+  it('should logged with module', () => {
+    const module = 'my-module';
+    logger = createLogger(module);
+    logger.info('message');
+    expect(info.mock.lastCall?.[0]).toMatch(module);
+  });
+
+  it('should logged if loglevel <= target level', () => {
+    logger.debug('debug message');
+    expect(debug).not.toBeCalled();
+
+    setLogLevel('trace');
+    logger.debug('debug message');
+    expect(debug).toBeCalled();
+  });
+
+  it('should not logged if loglevel > target level', () => {
+    setLogLevel('error');
+    logger.info('info message');
+    expect(info).not.toBeCalled();
+  });
+
+  it('should log nothing if loglevel is too large', () => {
+    setLogLevel(Infinity);
+    logger.error('error message');
+    expect(error).not.toBeCalled();
+  });
+});

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -1,21 +1,8 @@
 import { LIB_VERSION } from './version';
-import { bytes, BytesLike } from '@ckb-lumos/codec';
-
-function formatArgs(arg: unknown): string {
-  if (typeof arg === 'string') {
-    return arg;
-  }
-
-  try {
-    return bytes.hexify(bytes.bytify(arg as BytesLike));
-  } catch {
-    return JSON.stringify(arg);
-  }
-}
+import { formatMessage } from './internal';
 
 export function makeError(message = 'Unknown error', ...args: unknown[]): Error {
-  let i = 0;
-  const formatted = message.replace(/%s/g, () => formatArgs(args[i++]));
+  const formatted = formatMessage(message, ...args);
   return new Error(`[NexusWallet]: ${formatted}  (version=${LIB_VERSION})`);
 }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export { LIB_VERSION } from './version';
 export * as errors from './error';
 export * as asserts from './asserts';
-export { resolveProvider } from './internal';
+export { resolveProvider, formatMessage } from './internal';
+export * as logger from './logger';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,3 +3,4 @@ export * as errors from './error';
 export * as asserts from './asserts';
 export { resolveProvider, formatMessage } from './internal';
 export * as logger from './logger';
+export { createLogger } from './logger';

--- a/packages/utils/src/internal.ts
+++ b/packages/utils/src/internal.ts
@@ -30,6 +30,10 @@ function formatArgs(arg: unknown): string {
  * @param args
  */
 export function formatMessage(message: string, ...args: unknown[]): string {
-  let i = 0;
-  return message.replace(/%s/g, () => formatArgs(args[i++]));
+  let replaced = 0;
+  let formatted = message.replace(/%s/g, () => formatArgs(args[replaced++]));
+  if (replaced < args.length) {
+    formatted += ' ' + args.slice(replaced).map(formatArgs).join(' ');
+  }
+  return formatted;
 }

--- a/packages/utils/src/internal.ts
+++ b/packages/utils/src/internal.ts
@@ -1,6 +1,35 @@
 import type { Provider } from '@nexus-wallet/types/lib/services/common';
 import type { Promisable } from '@nexus-wallet/types';
+import { bytes, BytesLike } from '@ckb-lumos/codec';
 
 export function resolveProvider<T>(provider: Provider<T>): Promisable<T> {
   return provider instanceof Function ? provider() : provider;
+}
+
+function formatArgs(arg: unknown): string {
+  if (typeof arg === 'string') {
+    return arg;
+  }
+
+  try {
+    // TODO check if arg is a valid BytesLike string first
+    //  instead of just try to convert it
+    return bytes.hexify(bytes.bytify(arg as BytesLike));
+  } catch {
+    return JSON.stringify(arg);
+  }
+}
+
+/**
+ * format message with args, the %s will be replaced with args in order
+ * @example
+ * ```js
+ * formatMessage('hello %s', 'world') // => 'hello world'
+ * ```
+ * @param message
+ * @param args
+ */
+export function formatMessage(message: string, ...args: unknown[]): string {
+  let i = 0;
+  return message.replace(/%s/g, () => formatArgs(args[i++]));
 }

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,0 +1,48 @@
+import { formatMessage } from './internal';
+
+let adapter: Logger = console;
+let loglevel: LogLevel = 'info';
+
+export function createLogger(module = 'nexus'): Logger {
+  const log =
+    (method: keyof Logger) =>
+    (message?: string, ...args: unknown[]) => {
+      const currentLogLevel = typeof loglevel === 'string' ? LOG_LEVELS[loglevel] : loglevel;
+      if (LOG_LEVELS[method] < currentLogLevel || !message) return;
+      adapter[method](formatMessage(`${module}  ${message}`, ...args));
+    };
+
+  return {
+    trace: log('trace'),
+    debug: log('debug'),
+    info: log('info'),
+    warn: log('warn'),
+    error: log('error'),
+  };
+}
+
+export function setLogLevel(level: LogLevel): void {
+  loglevel = level;
+}
+
+export function setLogger(newAdapter: Logger): void {
+  adapter = newAdapter;
+}
+
+export interface Logger {
+  trace(message?: string, ...args: unknown[]): void;
+  debug(message?: string, ...args: unknown[]): void;
+  info(message?: string, ...args: unknown[]): void;
+  warn(message?: string, ...args: unknown[]): void;
+  error(message?: string, ...args: unknown[]): void;
+}
+
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | number;
+
+const LOG_LEVELS = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -3,13 +3,13 @@ import { formatMessage } from './internal';
 let adapter: Logger = console;
 let loglevel: LogLevel = 'info';
 
-export function createLogger(module = 'nexus'): Logger {
+export function createLogger(module = 'Nexus'): Logger {
   const log =
     (method: keyof Logger) =>
     (message?: string, ...args: unknown[]) => {
       const currentLogLevel = typeof loglevel === 'string' ? LOG_LEVELS[loglevel] : loglevel;
       if (LOG_LEVELS[method] < currentLogLevel || !message) return;
-      adapter[method](formatMessage(`${module}  ${message}`, ...args));
+      adapter[method](formatMessage(`[${module}]\t[${method.toUpperCase()}]\t${message}`, ...args));
     };
 
   return {


### PR DESCRIPTION
This PR introduced the `SessionMessenger` which helps to communicate between extension page and background service in a session scope. 

```ts
// define a CallMap to make it type-safe
type SessionMethods = {
  ping: Call<void, 'pong'>;
}

// background.js
const service = createSessionMessenger<SessionMethods>({ 
  adapter: browserExtensionAdapter, 
  sessionId: 'session1' 
});
service.register('ping', () => 'pong');

// content-script.js
const client = createSessionMessenger<SessionMethods>({
  adapter: browserExtensionAdapter,
  sessionId: 'session1'
});
await client.send('ping') // => 'pong'
```

We can check out more cases in the [test](https://github.com/ckb-js/nexus/blob/f00bcad4c0e089190d9343f45e281aaa27e6e77f/packages/extension-chrome/__tests__/messaging/session.ts)

BTW, this PR also

- defined [SessionMethods](https://github.com/ckb-js/nexus/blob/session-messenger/packages/extension-chrome/src/services/notification.ts#L10-L27) for `NotificationService` to help it communicate with extension page
- updated lumos to the latest develop
- added a simple logger
- fixed KeystoreService test performance issue
