### PR TITLE
feat: localhost is able to be added to whitelist

### DIFF
--- a/packages/extension-chrome/__tests__/services/config.ts
+++ b/packages/extension-chrome/__tests__/services/config.ts
@@ -42,6 +42,58 @@ describe('ConfigService', () => {
     });
   });
 
+  it('should setConfig with localhost hostname', async () => {
+    await expect(
+      service.setConfig({
+        config: {
+          ...fakeConfig,
+          whitelist: [
+            {
+              favicon: 'http://localhost:9180/favicon.ico',
+              host: 'localhost',
+            },
+          ],
+        },
+      }),
+    );
+    await expect(service.getConfig()).resolves.toEqual({
+      ...fakeConfig,
+      whitelist: [
+        {
+          favicon: 'http://localhost:9180/favicon.ico',
+          host: 'localhost',
+        },
+      ],
+      version: LIB_VERSION,
+    });
+  });
+
+  it('should setConfig with localhost:port hostname', async () => {
+    await expect(
+      service.setConfig({
+        config: {
+          ...fakeConfig,
+          whitelist: [
+            {
+              favicon: 'http://example.com/favicon.ico',
+              host: 'localhost:9180',
+            },
+          ],
+        },
+      }),
+    );
+    await expect(service.getConfig()).resolves.toEqual({
+      ...fakeConfig,
+      whitelist: [
+        {
+          favicon: 'http://example.com/favicon.ico',
+          host: 'localhost:9180',
+        },
+      ],
+      version: LIB_VERSION,
+    });
+  });
+
   it('setConfig with callback', async () => {
     await service.setConfig({
       config: (draft) => {
@@ -56,6 +108,22 @@ describe('ConfigService', () => {
     await expect(
       service.setConfig({
         config: { ...fakeConfig, selectedNetwork: '2' },
+      }),
+    ).rejects.toThrowError();
+  });
+
+  it('should throw when setConfig with wrong hostname', async () => {
+    await expect(
+      service.setConfig({
+        config: {
+          ...fakeConfig,
+          whitelist: [
+            {
+              favicon: 'http://localhost:9180/favicon.ico',
+              host: 'localhost:123123123',
+            },
+          ],
+        },
       }),
     ).rejects.toThrowError();
   });

--- a/packages/extension-chrome/src/services/config.ts
+++ b/packages/extension-chrome/src/services/config.ts
@@ -11,10 +11,12 @@ const NetworkSchema = joi.object<NetworkConfig>({
   displayName: joi.string().required(),
 });
 
-const TrustedHostSchema = joi.object<TrustedHost>({
-  host: joi.string().hostname().required(),
-  favicon: joi.string().uri().required(),
-});
+const TrustedHostSchema = joi
+  .object<TrustedHost>({
+    host: [joi.string().hostname(), joi.string().pattern(new RegExp(`^localhost(:[0-9]{2,5})?$`))],
+    favicon: joi.string().uri().required(),
+  })
+  .with('favicon', 'host');
 
 const ConfigSchema = joi.object<Config>({
   nickname: joi.string().required(),


### PR DESCRIPTION
Adding localhost host names to white list won't pass joi validation, thus call `window.ckb.enable()` on localhost websites throws errors. Which may not be convenient for website development.

This PR enables nexus to add localhost to whitelist.