### PR TITLE
feat: supported event hub

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,17 @@
+# Events
+
+## `networkChanged`
+
+Emitted when the network changes.
+
+### Parameters
+
+- `networkName`: `'ckb' | 'ckb_testnet' | string`;
+
+### Example
+
+```js
+ckb.on('networkChanged', (networkName) => {
+  console.log(networkName);
+});
+```

--- a/packages/extension-chrome/__tests__/rpc/event.test.ts
+++ b/packages/extension-chrome/__tests__/rpc/event.test.ts
@@ -11,14 +11,15 @@ it('should the networkChanged fired when config has updated', async () => {
 
   ckb.on('networkChanged', mockListener);
   await ckb.request({ method: 'debug_setConfig', params: { selectedNetwork: 'testnet' } });
+  await ckb.request({ method: 'debug_setConfig', params: { selectedNetwork: 'testnet' } });
+  await ckb.request({ method: 'debug_setConfig', params: { selectedNetwork: 'testnet' } });
   await asyncSleep(50);
 
+  expect(mockListener).toHaveBeenCalledTimes(1);
   expect(mockListener).toHaveBeenCalledWith('ckb_testnet');
 });
 
 it('should the walletInitialized fired when wallet has initialized', async () => {
-  // crypto is a slow module, so we need to increase the timeout
-  jest.setTimeout(10_000);
   const { ckb } = createTestRpcServer({ storage: createInMemoryStorage });
 
   const mockListener = jest.fn();
@@ -28,4 +29,5 @@ it('should the walletInitialized fired when wallet has initialized', async () =>
   await asyncSleep(50);
 
   expect(mockListener).toHaveBeenCalled();
-});
+  // crypto is a slow module, so we need to increase the timeout
+}, 10_000);

--- a/packages/extension-chrome/__tests__/rpc/event.test.ts
+++ b/packages/extension-chrome/__tests__/rpc/event.test.ts
@@ -1,0 +1,29 @@
+import { createTestRpcServer } from './helper';
+import { asyncSleep } from '@ckb-lumos/e2e-test/src/utils';
+import { createInMemoryStorage } from '../../src/services/storage';
+
+it('should the networkChanged fired when config has updated', async () => {
+  const { ckb } = createTestRpcServer();
+
+  const mockListener = jest.fn();
+
+  ckb.on('networkChanged', mockListener);
+  await ckb.request({ method: 'debug_setConfig', params: { selectedNetwork: 'testnet' } });
+  await asyncSleep(50);
+
+  expect(mockListener).toHaveBeenCalledWith('ckb_testnet');
+});
+
+it('should the walletInitialized fired when wallet has initialized', async () => {
+  // crypto is a slow module, so we need to increase the timeout
+  jest.setTimeout(10_000);
+  const { ckb } = createTestRpcServer({ storage: createInMemoryStorage });
+
+  const mockListener = jest.fn();
+
+  ckb.on('walletInitialized', mockListener);
+  await ckb.request({ method: 'debug_initWallet' });
+  await asyncSleep(50);
+
+  expect(mockListener).toHaveBeenCalled();
+});

--- a/packages/extension-chrome/__tests__/rpc/event.test.ts
+++ b/packages/extension-chrome/__tests__/rpc/event.test.ts
@@ -6,6 +6,8 @@ it('should the networkChanged fired when config has updated', async () => {
   const { ckb } = createTestRpcServer();
 
   const mockListener = jest.fn();
+  // make sure the network is mainnet at the beginning
+  await ckb.request({ method: 'debug_setConfig', params: { selectedNetwork: 'mainnet' } });
 
   ckb.on('networkChanged', mockListener);
   await ckb.request({ method: 'debug_setConfig', params: { selectedNetwork: 'testnet' } });

--- a/packages/extension-chrome/__tests__/rpc/helper.ts
+++ b/packages/extension-chrome/__tests__/rpc/helper.ts
@@ -1,5 +1,5 @@
 import './_patch';
-import { Storage } from '@nexus-wallet/types';
+import { InjectedCkb, Storage } from '@nexus-wallet/types';
 import { JSONRPCClient } from 'json-rpc-2.0';
 import { createServer } from '../../src/rpc';
 import { createModulesFactory, ModuleProviderMap, ModulesFactory } from '../../src/services/factory';
@@ -7,12 +7,21 @@ import { RpcMethods } from '../../src/rpc/types';
 import { mockPlatformService, mockStorage } from '../helpers';
 import '../../src/rpc/debugImpl';
 import '../../src/rpc/walletImpl';
+import { createInjectedCkb, TypedEventClient, TypedRpcClient } from '../../src/injectedCkb';
+import { errors } from '@nexus-wallet/utils';
 
 export interface RpcTestHelper {
+  /**
+   * @deprecated please migrate to {@link InjectedCkb.request}
+   * @param method
+   * @param params
+   */
   request<Method extends keyof RpcMethods>(
     method: Method,
     params?: RpcMethods[Method]['params'],
   ): RpcMethods[Method]['result'];
+
+  ckb: InjectedCkb<TypedRpcClient, TypedEventClient>;
 
   factory: ModulesFactory;
 }
@@ -27,15 +36,27 @@ export function createTestRpcServer<S = any, P = any>(payload: Partial<ModulePro
   const platform = payload.platform || (() => mockPlatformService);
   const factory = createModulesFactory({ storage, platform });
   const server = createServer(factory);
+  const eventHub = factory.get('eventHub');
 
   const client = new JSONRPCClient(async (req) => {
     const response = await server.handleRequest({ request: req, sender: null });
     client.receive(response!);
   });
 
+  const ckb = createInjectedCkb({
+    rpcClient: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      request: async (payload: any) => client.request(payload.method, payload.params),
+    },
+    eventClient: {
+      on: eventHub.on.bind(eventHub),
+      removeListener: errors.unimplemented,
+    },
+  });
+
   const request: RpcTestHelper['request'] = (method, params) => {
     return client.request(String(method), params);
   };
 
-  return { request, factory };
+  return { request, factory, ckb };
 }

--- a/packages/extension-chrome/__tests__/services/config.test.ts
+++ b/packages/extension-chrome/__tests__/services/config.test.ts
@@ -2,6 +2,7 @@ import { createConfigService } from '../../src/services/config';
 import { createInMemoryStorage } from '../../src/services/storage';
 import { ConfigService } from '@nexus-wallet/types';
 import { LIB_VERSION } from '@nexus-wallet/utils';
+import { createEventHub } from '../../src/services/event';
 
 let service: ConfigService;
 const fakeConfig = {
@@ -12,7 +13,7 @@ const fakeConfig = {
 };
 
 beforeEach(async () => {
-  service = createConfigService({ storage: createInMemoryStorage() });
+  service = createConfigService({ storage: createInMemoryStorage(), eventHub: createEventHub() });
 });
 
 it('should throw when trying to get config before set', async () => {

--- a/packages/extension-chrome/__tests__/services/internal.test.ts
+++ b/packages/extension-chrome/__tests__/services/internal.test.ts
@@ -1,16 +1,11 @@
-import { createInternalService, FULL_OWNERSHIP_EXTERNAL_PARENT_PATH } from '../../src/services/internal';
-import { createKeystoreService } from '../../src/services/keystore';
 import { createInMemoryStorage } from '../../src/services/storage';
-import { createConfigService } from '../../src/services/config';
+import { FULL_OWNERSHIP_EXTERNAL_PARENT_PATH } from '../../src/services/internal';
+import { createModulesFactory } from '../../src/services/factory';
 import { mockPlatformService } from '../helpers';
 
 test('internal service', async () => {
-  const storage = createInMemoryStorage();
-  const internalService = createInternalService({
-    keystoreService: createKeystoreService({ storage }),
-    configService: createConfigService({ storage }),
-    platformService: mockPlatformService,
-  });
+  const factory = createModulesFactory({ storage: createInMemoryStorage, platform: () => mockPlatformService });
+  const internalService = factory.get('internalService');
 
   await internalService.initWallet({
     nickname: 'Nexus Dev',
@@ -18,8 +13,8 @@ test('internal service', async () => {
     password: '123456',
   });
 
-  const configService = createConfigService({ storage });
-  const keystoreService = createKeystoreService({ storage });
+  const configService = factory.get('configService');
+  const keystoreService = factory.get('keystoreService');
 
   await expect(internalService.isInitialized()).resolves.toBe(true);
   await expect(Promise.resolve(keystoreService.hasInitialized())).resolves.toBe(true);

--- a/packages/extension-chrome/src/background/main.ts
+++ b/packages/extension-chrome/src/background/main.ts
@@ -2,9 +2,10 @@ import './patch';
 import '../rpc/walletImpl';
 import '../rpc/debugImpl';
 import { createLogger, LIB_VERSION } from '@nexus-wallet/utils';
-import { Endpoint, onMessage } from 'webext-bridge';
+import { Endpoint, onMessage, sendMessage } from 'webext-bridge';
 import { createServer } from '../rpc';
 import { makeBrowserExtensionModulesFactory } from '../services';
+import browser from 'webextension-polyfill';
 
 const logger = createLogger();
 logger.info(`Hi, this is Nexus@%s`, LIB_VERSION);
@@ -14,6 +15,17 @@ if (process.env.NODE_ENV === 'development') {
 
 const factory = makeBrowserExtensionModulesFactory();
 const server = createServer<Endpoint>(factory);
+
+// send event data to content script
+const eventHub = factory.get('eventHub');
+eventHub.on('networkChanged', async (networkName) => {
+  const tabs = await browser.tabs.query({});
+  // TODO optimize me, only send to subscribed tabs
+  tabs.forEach((tab) => {
+    if (!tab.id) return;
+    void sendMessage('event', { eventName: 'networkChanged', params: [networkName] }, `content-script@${tab.id}`);
+  });
+});
 
 // listen message from content script
 onMessage('rpc', async ({ data, sender }) => {

--- a/packages/extension-chrome/src/injectedCkb/index.ts
+++ b/packages/extension-chrome/src/injectedCkb/index.ts
@@ -1,0 +1,44 @@
+import { InjectedCkb } from '@nexus-wallet/types';
+import { LIB_VERSION } from '@nexus-wallet/utils';
+import { RpcMethods } from '../rpc/types';
+import { EventMap } from '../services/event';
+import { EventClient, RpcClient } from '@nexus-wallet/types/lib/injected';
+
+type JsonRpcRequest<M extends string | number = string, P = unknown> = {
+  method: M;
+  params?: P;
+};
+
+type KeyOf<T> = Extract<keyof T, string>;
+
+export interface TypedRpcClient extends RpcClient {
+  request<M extends KeyOf<RpcMethods>>(payload: JsonRpcRequest<M, RpcMethods[M]['params']>): RpcMethods[M]['result'];
+  // uncomment me when we have a better way to handle unknown
+  // request(payload: JsonRpcRequest): Promise<unknown>;
+}
+
+export interface TypedEventClient extends EventClient {
+  on<E extends keyof EventMap>(event: E, listener: EventMap[E]): void;
+  removeListener<E extends keyof EventMap>(event: E, listener: (...args: Parameters<EventMap[E]>) => void): void;
+}
+
+export function createInjectedCkb({
+  rpcClient,
+  eventClient,
+}: {
+  rpcClient: TypedRpcClient;
+  eventClient: TypedEventClient;
+}): InjectedCkb<TypedRpcClient, TypedEventClient> {
+  return {
+    version: LIB_VERSION,
+    request: rpcClient.request.bind(rpcClient),
+    on: eventClient.on.bind(eventClient),
+    removeListener: eventClient.removeListener.bind(eventClient),
+    enable: /* istanbul ignore next */ () => {
+      throw new Error('Deprecated, please migrate to request');
+    },
+    isEnabled: /* istanbul ignore next */ () => {
+      throw new Error('Deprecated, please migrate to request');
+    },
+  };
+}

--- a/packages/extension-chrome/src/messaging/internal.ts
+++ b/packages/extension-chrome/src/messaging/internal.ts
@@ -59,3 +59,14 @@ export function isNexusMessage<T>(obj: unknown): obj is NexusMessage<T> {
   if (obj == null) return false;
   return NEXUS_MESSAGE_TYPE_KEY in obj;
 }
+
+type EventObject<Evt extends string, Params extends unknown[]> = { eventName: Evt; params?: Params };
+
+/* istanbul ignore next */
+export function isEventObject<Evt extends string, Params extends unknown[]>(
+  obj: unknown,
+): obj is EventObject<Evt, Params> {
+  if (typeof obj !== 'object') return false;
+  if (obj == null) return false;
+  return 'eventName' in obj;
+}

--- a/packages/extension-chrome/src/rpc/debugImpl.ts
+++ b/packages/extension-chrome/src/rpc/debugImpl.ts
@@ -9,4 +9,14 @@ if (process.env.NODE_ENV === 'development') {
       password: '123456',
     });
   });
+
+  addMethod('debug_setConfig', async (payload, { resolveService }) => {
+    const configService = resolveService('configService');
+    await configService.setConfig({ config: payload });
+  });
+
+  addMethod('debug_getConfig', async (_, { resolveService }) => {
+    const configService = resolveService('configService');
+    return configService.getConfig();
+  });
 }

--- a/packages/extension-chrome/src/rpc/types.ts
+++ b/packages/extension-chrome/src/rpc/types.ts
@@ -1,19 +1,21 @@
 import { HexString, Script } from '@ckb-lumos/lumos';
 import { Modules } from '../services';
-import { Call, CallMap } from '@nexus-wallet/types';
+import { Config as NexusConfig } from '@nexus-wallet/types/lib/services/ConfigService';
+import { AsyncCall, AsyncCallMap } from '@nexus-wallet/types/lib/call';
 
-export interface WalletMethods extends CallMap {
-  wallet_enable: Call<void, void>;
-  wallet_isEnabled: Call<void, boolean>;
-  wallet_getNetworkName: Call<void, string>;
+export interface WalletMethods extends AsyncCallMap {
+  wallet_enable: AsyncCall<void, void>;
+  wallet_isEnabled: AsyncCall<void, boolean>;
+  wallet_getNetworkName: AsyncCall<void, string>;
 
-  wallet_fullOwnership_getUnusedLocks: Call<void, Script[]>;
-
-  wallet_fullOwnership_signData: Call<{ data: HexString }, Promise<string>>;
+  wallet_fullOwnership_getUnusedLocks: AsyncCall<void, Script[]>;
+  wallet_fullOwnership_signData: AsyncCall<{ data: HexString }, HexString>;
 }
 
-export interface DebugMethods extends CallMap {
-  debug_initWallet: Call<void, void>;
+export interface DebugMethods extends AsyncCallMap {
+  debug_initWallet: AsyncCall<void, void>;
+  debug_setConfig: AsyncCall<Partial<NexusConfig>, void>;
+  debug_getConfig: AsyncCall<void, NexusConfig>;
 }
 
 /**

--- a/packages/extension-chrome/src/services/config.ts
+++ b/packages/extension-chrome/src/services/config.ts
@@ -1,8 +1,11 @@
 import { ConfigService, Storage } from '@nexus-wallet/types';
 import type { Config, NetworkConfig, TrustedHost } from '@nexus-wallet/types/lib/services';
-import { errors, LIB_VERSION } from '@nexus-wallet/utils';
+import { createLogger, errors, LIB_VERSION } from '@nexus-wallet/utils';
 import produce from 'immer';
 import joi from 'joi';
+import { EventHub } from './event';
+
+const logger = createLogger();
 
 const NetworkSchema = joi.object<NetworkConfig>({
   id: joi.string().required(),
@@ -32,8 +35,11 @@ const DEFAULT_CONFIG = Object.freeze({
   selectedNetwork: '',
 });
 
-export function createConfigService(payload: { storage: Storage<{ config: Config }> }): ConfigService {
-  const { storage } = payload;
+export function createConfigService(payload: {
+  storage: Storage<{ config: Config }>;
+  eventHub: EventHub;
+}): ConfigService {
+  const { storage, eventHub } = payload;
 
   const getConfig = async (): Promise<Config> => {
     const config = await storage.getItem('config');
@@ -44,18 +50,18 @@ export function createConfigService(payload: { storage: Storage<{ config: Config
   };
 
   const setConfig = async (configOrUpdate: Partial<Config> | ((config: Config) => void)): Promise<void> => {
-    const original = (await storage.getItem('config')) || DEFAULT_CONFIG;
+    const oldConfig = (await storage.getItem('config')) || DEFAULT_CONFIG;
 
     const updated = (() => {
       if (typeof configOrUpdate === 'function') {
-        return produce(original, () => {
-          configOrUpdate(original);
+        return produce(oldConfig, () => {
+          configOrUpdate(oldConfig);
         });
       }
       return configOrUpdate;
     })();
 
-    const newConfig = Object.assign({}, original, updated) as Config;
+    const newConfig = Object.assign({}, oldConfig, updated) as Config;
 
     const validationResult = ConfigSchema.validate(newConfig);
 
@@ -66,13 +72,19 @@ export function createConfigService(payload: { storage: Storage<{ config: Config
     const { networks, selectedNetwork } = newConfig;
 
     // check if selectedNetwork is in networks
-    const isSelectedInNetworks = networks.find((network) => network.id === selectedNetwork);
-    if (!isSelectedInNetworks) {
+    const newSelectedNetwork = networks.find((network) => network.id === selectedNetwork);
+    if (!newSelectedNetwork) {
       errors.throwError(
         `Selected network "%s" is not found in networks, please check if the selected one is in networks[].id`,
         selectedNetwork,
       );
     }
+
+    if (newConfig.selectedNetwork !== oldConfig.selectedNetwork) {
+      eventHub.emit('networkChanged', newSelectedNetwork.networkName);
+    }
+
+    logger.info('Config updated \nold: %s \nnew: %s', oldConfig, newConfig);
 
     await storage.setItem('config', newConfig);
   };

--- a/packages/extension-chrome/src/services/event/index.ts
+++ b/packages/extension-chrome/src/services/event/index.ts
@@ -1,0 +1,28 @@
+import { NetworkName } from '@nexus-wallet/types/lib/services';
+import { EventEmitter } from 'events';
+
+export interface EventMap {
+  networkChanged: (networkName: NetworkName) => void;
+  walletInitialized: () => void;
+}
+
+export interface EventHub {
+  on<K extends keyof EventMap>(event: K, callback: EventMap[K]): void;
+  emit<K extends keyof EventMap>(event: K, ...args: Parameters<EventMap[K]>): void;
+  removeListener<K extends keyof EventMap>(event: K, listener: EventMap[K]): void;
+
+  // uncomment me if we want to support wildcard event
+  // emit(event: string, ...args: unknown[]): void;
+  // on(event: string, callback: EventListener): void;
+  // export type EventListener = (...args: unknown[]) => void;
+}
+
+export function createEventHub(): EventHub {
+  const emitter = new EventEmitter();
+
+  return {
+    on: emitter.on,
+    emit: emitter.emit,
+    removeListener: emitter.removeListener,
+  };
+}

--- a/packages/extension-chrome/src/services/event/index.ts
+++ b/packages/extension-chrome/src/services/event/index.ts
@@ -2,7 +2,14 @@ import { NetworkName } from '@nexus-wallet/types/lib/services';
 import { EventEmitter } from 'events';
 
 export interface EventMap {
+  /**
+   * available for all pages
+   * @param networkName
+   */
   networkChanged: (networkName: NetworkName) => void;
+  /**
+   * available only for extension
+   */
   walletInitialized: () => void;
 }
 
@@ -21,8 +28,8 @@ export function createEventHub(): EventHub {
   const emitter = new EventEmitter();
 
   return {
-    on: emitter.on,
-    emit: emitter.emit,
-    removeListener: emitter.removeListener,
+    on: emitter.on.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
   };
 }

--- a/packages/extension-chrome/src/services/factory/index.ts
+++ b/packages/extension-chrome/src/services/factory/index.ts
@@ -3,6 +3,7 @@ import { ConfigService, KeystoreService, PlatformService, Storage } from '@nexus
 import { createConfigService } from '../config';
 import { createInternalService, InternalService } from '../internal';
 import { createKeystoreService } from '../keystore';
+import { createEventHub, EventHub } from '../event';
 
 export interface ModulesFactory {
   get<K extends keyof Modules>(name: K): Modules[K];
@@ -18,6 +19,7 @@ export interface Modules<S = unknown, P = unknown> {
   configService: ConfigService;
   internalService: InternalService;
   platformService: PlatformService<P>;
+  eventHub: EventHub;
 }
 
 export function createModulesFactory<S, P>({ storage, platform }: ModuleProviderMap<S, P>): ModulesFactory {
@@ -30,6 +32,7 @@ export function createModulesFactory<S, P>({ storage, platform }: ModuleProvider
     keystoreService: awilix.asFunction(createKeystoreService).singleton(),
     notificationService: platformResolover,
     platformService: platformResolover,
+    eventHub: awilix.asFunction(createEventHub).singleton(),
   });
 
   return {

--- a/packages/extension-chrome/src/services/internal.ts
+++ b/packages/extension-chrome/src/services/internal.ts
@@ -1,5 +1,6 @@
 import { ConfigService, KeystoreService, PlatformService } from '@nexus-wallet/types';
 import { NetworkConfig } from '@nexus-wallet/types/lib/services';
+import { EventHub } from './event';
 
 // full ownership with external chain
 export const FULL_OWNERSHIP_EXTERNAL_PARENT_PATH = `m/44'/309'/0'/0`;
@@ -25,8 +26,9 @@ export function createInternalService(payload: {
   keystoreService: KeystoreService;
   configService: ConfigService;
   platformService: PlatformService;
+  eventHub: EventHub;
 }): InternalService {
-  const { keystoreService, configService, platformService } = payload;
+  const { keystoreService, configService, platformService, eventHub } = payload;
 
   const impl: InternalService = {
     initWallet: async (payload) => {
@@ -44,6 +46,8 @@ export function createInternalService(payload: {
         mnemonic,
         paths: [FULL_OWNERSHIP_EXTERNAL_PARENT_PATH, FULL_OWNERSHIP_INTERNAL_PARENT_PATH, RULE_BASED_PARENT_PATH],
       });
+
+      eventHub.emit('walletInitialized');
     },
 
     isInitialized: () => Promise.resolve(keystoreService.hasInitialized()),

--- a/packages/types/src/call.ts
+++ b/packages/types/src/call.ts
@@ -6,3 +6,9 @@ export interface Call<Param, Result> {
   params: Param;
   result: Result;
 }
+
+export interface AsyncCall<Param, Result> {
+  params: Param;
+  result: PromiseLike<Result>;
+}
+export type AsyncCallMap = Record<string, AsyncCall<unknown, unknown>>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,4 +9,4 @@ export type {
 } from './services';
 export type { Storage } from './storage';
 export type { Promisable, Paginate, Cursor } from './base';
-export type { Call, CallMap, CallResult, CallParam } from './call';
+export type { AsyncCall, AsyncCallMap, Call, CallMap, CallResult, CallParam } from './call';

--- a/packages/types/src/injected.ts
+++ b/packages/types/src/injected.ts
@@ -2,20 +2,50 @@ import { Cell, HexString, Script, Transaction } from '@ckb-lumos/lumos';
 import { BytesLike } from '@ckb-lumos/codec';
 import { Paginate } from './base';
 
-export interface InjectedCkb {
+export interface RpcClient {
+  request(payload: { method: string; params: unknown }): PromiseLike<unknown>;
+}
+
+export interface EventClient {
+  on(eventName: string, listener: (...args: unknown[]) => void): void;
+  removeListener(eventName: string, listener: (...args: unknown[]) => void): void;
+}
+
+export interface InjectedCkb<R extends RpcClient = RpcClient, E extends EventClient = EventClient> {
   readonly version: string;
 
   /**
+   * send a JSON-RPC request to the wallet
+   */
+  request: R['request'];
+
+  /**
+   * subscribe to an event from the wallet
+   *
+   */
+  on: E['on'];
+
+  /**
+   * unsubscribe to an event from the wallet
+   */
+  removeListener: E['removeListener'];
+
+  /**
    * Enable the wallet for a dApp
+   * @deprecated please migrate to {@link InjectedCkb.request}
    */
   enable(): Promise<CkbProvider>;
 
   /**
    * Check the wallet is enabled for a dApp
+   * @deprecated please migrate to {@link InjectedCkb.request}
    */
   isEnabled(): Promise<boolean>;
 }
 
+/**
+ * @deprecated please migrate to {@link InjectedCkb.request}, e.g. `ckb.request({ method: "wallet_fullOwnership_getLiveCell", params: {} })`
+ */
 export interface CkbProvider {
   getNetworkName(): Promise<Network>;
 


### PR DESCRIPTION
This PR added an `EventHub` module to support publish/subscribe event between modules and `InjectedCkb`

## EventHub

### In Injected Script

```js
ckb.on('networkChanged', (networkName) => {
  console.log('network changed', networkName)
})

await window.ckb.request({
  method:'debug_updateConfig', 
  params: { selectedNetwork: 'testnet' }
})

// console will output "network changed ckb_testnet"
```

### In Modules

```ts
function myRegisteredModule({ eventHub }) {
  // ...
  eventHub.emit('networkChanged');
}
```

## Deprecated `ckb.enable` and `ckb.isEnabled`

<img width="351" alt="image" src="https://user-images.githubusercontent.com/7511174/222162746-88faad7c-dddf-4ec5-9797-8f7eb62152dc.png">

`InjectedCkb` should be a pure client, we should not treat it as an SDK, otherwise it may be hard to keep it light and simple, this PR refactored `InjectedCkb` into a pure `EventClient` + `RpcClient`, `InjectedCkb` will expose only three methods

```ts
interface InjectedCkb {
  request(req: { method: string, params?: any }): Promise<any>;
  on(event: string, listener: (...args: any[])): void;
  removeListener(event:string, listener: (...args: any[])): void;
}
```

## Added Debug methods `debug_setConfig` and `debug_getConfig`

Making the debugging easier