### PR TITLE
feat: make rpc error more friendly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': 'error',
         '@typescript-eslint/no-floating-promises': 'error',
         'no-console': 'warn',
+        '@typescript-eslint/no-throw-literal': 'error',
       },
     },
   ],

--- a/docs/error.md
+++ b/docs/error.md
@@ -1,0 +1,106 @@
+# Error Handling
+
+Errors can occur in the Nexus wallet browser extension, but we've made efforts to make them user-friendly for both
+developers and end-users. Whenever an error occurs, an instance of the `Error` object is thrown, which has the following
+structure:
+
+```ts
+interface Error {
+  message: string;
+  data?: any;
+}
+```
+
+The `message` field is designed to be easy for dApps to display to end-users, while the optional `data` field provides
+more detailed information about the error.
+
+To display the error message, we recommend using the following format:
+
+```markdown
+<details>
+  <summary>${error.message}</summary>
+  <pre>${error.data && JSON.stringify(error.data, null, 2)}</pre>
+</details>;
+```
+
+This format allows developers to debug the error by displaying more details in the `data` field if it exists.
+
+## Debugging RPC Requests
+
+When an RPC request fails, the error message will be printed to the console if it's not caught. If more detailed
+information is needed to debug the error, the `data` field of the error object can be checked.
+
+For example, if a request to sign a transaction fails due to a non-live cell input, the error message will be:
+
+> Cannot resolve the cell, please check if the network is correct or if the cell is still live.
+
+If more details about the error are needed, the `data` field of the error object can be printed. The data will indicate
+which cell was resolved incorrectly, like this:
+
+```json
+{
+  "txHash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+  "index": "0x0"
+}
+```
+
+```js
+await window.ckb
+  .request({
+    method: 'wallet_fullOwnership_signTransaction',
+    params: {
+      tx: {
+        version: '0x0',
+        cellDeps: [
+          {
+            // non-live cell as the cell dep
+            // 👇
+            outPoint: {
+              txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              index: '0x0',
+            },
+            depType: 'depGroup',
+          },
+        ],
+        headerDeps: [],
+        inputs: [
+          {
+            // non-live cell as the input
+            // 👇
+            since: '0x0',
+            previousOutput: {
+              txHash: '0x0000000000000000000000000000000000000000000000000000000000000001',
+              index: '0x0',
+            },
+          },
+        ],
+        outputs: [
+          {
+            capacity: '0x2540be400',
+            lock: {
+              codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+              hashType: 'type',
+              args: '0x477de073e7ec94aeb74184b981670e843dcb0eb2',
+            },
+          },
+          {
+            capacity: '0x150056c218',
+            lock: {
+              args: '0x8caa5da2c3323da6018ad39dc15da2ed7d5932d6',
+              codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+              hashType: 'type',
+            },
+          },
+        ],
+        outputsData: ['0x', '0x'],
+        witnesses: [
+          '0x5500000010000000550000005500000041000000b6da2d194cc30c06b9f71fc7c474d2bb90fd2c4a7de66b121d0fdf5dcb2bcdd11c2a8a4f6d4ac5165fe013cdfb18f09f1578251639911f747eb9cbb661ca723600',
+        ],
+      },
+    },
+  })
+  .catch((error) => {
+    console.log(error.message);
+    console.log(error.data);
+  });
+```

--- a/packages/extension-chrome/__tests__/rpc/middleware.test.ts
+++ b/packages/extension-chrome/__tests__/rpc/middleware.test.ts
@@ -1,7 +1,10 @@
 import { createTestRpcServer } from './helper';
 import { createInMemoryStorage } from '../../src/services/storage';
+import { errorMiddleware } from '../../src/rpc/middlewares/errorMiddleware';
+import { createJSONRPCRequest, JSONRPCServer } from 'json-rpc-2.0';
+import { NexusCommonErrors, NexusError } from '../../src/errors';
 
-describe('rpc/middleware', () => {
+describe('Middlewares#whitelistMiddleware', () => {
   it('should request be baned when Nexus is not initialized', async () => {
     const { request } = createTestRpcServer({ storage: createInMemoryStorage });
 
@@ -19,5 +22,26 @@ describe('rpc/middleware', () => {
     // but other methods is not registered in RPC
     await expect(request('other_method')).rejects.not.toThrowError(/whitelist/);
     await expect(request('other_method')).rejects.toThrowError(/Method not found/);
+  });
+});
+
+describe('Middlewares#errorMiddleware', () => {
+  it('should receive NexusError response when the NexusError was thrown', async () => {
+    const server = new JSONRPCServer();
+
+    server.applyMiddleware(errorMiddleware);
+    server.addMethod('unknown', () => {
+      throw NexusError.create('Unknown');
+    });
+
+    const res = await server.receive(createJSONRPCRequest(0, 'unknown'));
+    expect(res?.error?.message).toMatch(/Unknown/);
+
+    server.addMethod('object', () => {
+      throw NexusCommonErrors.RequestCkbFailed({ method: 'some_method', params: [] });
+    });
+    const res2 = await server.receive(createJSONRPCRequest(0, 'object'));
+    expect(res2?.error?.message).toMatch(/request.*failed/i);
+    expect(res2?.error?.data).toMatchObject({ method: 'some_method', params: [] });
   });
 });

--- a/packages/extension-chrome/src/errors/NexusError.ts
+++ b/packages/extension-chrome/src/errors/NexusError.ts
@@ -1,0 +1,27 @@
+/**
+ * an error to make RPC could return a friendly error
+ */
+export class NexusError<T = unknown> extends Error {
+  __NEXUS_ERROR__ = true;
+  code: number;
+  data?: unknown;
+
+  private constructor({ code, message, data }: { code: number; message: string; data?: T }) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+
+  static create<T>(opt: { code?: number; message: string; data?: T } | string): NexusError<T> {
+    if (typeof opt === 'string') {
+      return new NexusError({ code: -1, message: opt });
+    }
+
+    return new NexusError({ code: opt.code ?? -1, message: opt.message, data: opt.data });
+  }
+
+  static isNexusError(error: unknown): error is NexusError {
+    if (!error || typeof error !== 'object') return false;
+    return '__NEXUS_ERROR__' in error && !!error.__NEXUS_ERROR__;
+  }
+}

--- a/packages/extension-chrome/src/errors/index.ts
+++ b/packages/extension-chrome/src/errors/index.ts
@@ -1,0 +1,2 @@
+export { NexusError } from './NexusError';
+export { NexusCommonErrors } from './list';

--- a/packages/extension-chrome/src/errors/list.ts
+++ b/packages/extension-chrome/src/errors/list.ts
@@ -1,0 +1,35 @@
+import { OutPoint } from '@ckb-lumos/base';
+import { NexusError } from './NexusError';
+
+function prepareNexusError<T>(opts: {
+  code?: number;
+  reason: string;
+  suggestion?: string;
+}): (data?: T) => NexusError<T> {
+  return (data?: T) => {
+    const message = `${opts.reason}, ${opts.suggestion}`;
+    return NexusError.create({ code: opts.code, message, data });
+  };
+}
+
+/**
+ * A list of errors that help to tell the end user what happened,
+ * and provide some suggestions to resolve the problem.
+ */
+export const NexusCommonErrors = {
+  ApproveRejected: prepareNexusError({
+    reason: 'The approval was rejected',
+  }),
+  RequestTimeout: prepareNexusError({
+    reason: 'The request was timeout',
+    suggestion: 'please try later',
+  }),
+  RequestCkbFailed: prepareNexusError({
+    reason: 'Request CKB node failed, the connected node is not available now',
+    suggestion: 'please try later or switch to another node',
+  }),
+  CellNotFound: prepareNexusError<OutPoint>({
+    reason: 'Cannot resolve the cell',
+    suggestion: 'please check if the selected network is correct or the cell is still live',
+  }),
+};

--- a/packages/extension-chrome/src/rpc/middlewares/errorMiddleware.ts
+++ b/packages/extension-chrome/src/rpc/middlewares/errorMiddleware.ts
@@ -1,0 +1,14 @@
+import { createJSONRPCErrorResponse, JSONRPCServerMiddleware } from 'json-rpc-2.0';
+import { NexusError } from '../../errors';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const errorMiddleware: JSONRPCServerMiddleware<any> = async (next, request, serverParams) => {
+  try {
+    return await next(request, serverParams);
+  } catch (e) {
+    if (NexusError.isNexusError(e)) {
+      return createJSONRPCErrorResponse(request.id!, e.code, e.message, e.data);
+    }
+    throw e;
+  }
+};

--- a/packages/extension-chrome/src/rpc/server.ts
+++ b/packages/extension-chrome/src/rpc/server.ts
@@ -3,6 +3,7 @@ import { ModulesFactory } from '../services';
 import { JSONRPCRequest, JSONRPCResponse, JSONRPCServer } from 'json-rpc-2.0';
 import { whitelistMiddleware } from './middlewares/whitelistMiddleware';
 import { createLogger } from '@nexus-wallet/utils';
+import { errorMiddleware } from './middlewares/errorMiddleware';
 
 export const methods: Record<string, (...args: unknown[]) => unknown> = {};
 export const logger = createLogger();
@@ -27,6 +28,7 @@ interface NexusRpcServer<Sender> {
  */
 export function createServer<Sender>(factory: ModulesFactory): NexusRpcServer<Sender> {
   const server = new JSONRPCServer<ServerParams>();
+  server.applyMiddleware(errorMiddleware);
   server.applyMiddleware(whitelistMiddleware);
 
   const registered = Object.keys(methods);

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -1,8 +1,8 @@
 import { LIB_VERSION } from './version';
-import { formatMessageWithPrefix } from './internal';
+import { formatMessage } from './internal';
 
 export function makeError(...args: unknown[]): Error {
-  const formatted = formatMessageWithPrefix('[NexusWallet]:', ...args);
+  const formatted = formatMessage(...args);
   return new Error(`${formatted}\t(version=${LIB_VERSION})`);
 }
 


### PR DESCRIPTION
This PR make the JSON RPC error response more friendly

```ts
interface Error<T> {
  // for both end-user and developer to know what 
  message: string,
  // for developer, more details about the error, 
  // e.g. when a cell cannot be resolved, the `data` will be a outPoint
  data?: T
}
```

checkout the [error handling](https://github.com/ckb-js/nexus/blob/friendly-rpc-error-new/docs/error.md) for more detail

## How 

```js
if (incorrectCondition) {
  throw NexusError.create({ message: 'Error message' })
}

// or
if (anotherCondition) {
  throw NexusCommonErrors.RequestTimeOut({
    method: 'get_transactions', 
    params: [...]
  });
}
```