### PR TITLE
chore: bypass protect branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,10 +57,10 @@ jobs:
         with:
           submodules: recursive
 
-      #      - name: Set up git
-      #        run: |
-      #          git config user.name github-actions
-      #          git config user.email github-actions@github.com
+      - name: Set up git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
       - uses: ./.github/actions/install-deps
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,19 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Enabled permissions on GITHUB_TOKEN
+permissions:
+  # To be able to push to the repo
+  contents: write
+  # To update the pr description with canary info
+  pull-requests: write
+  # For pr-check to create a status
+  statuses: write
+  # Needed to create PR statuses/checks
+  checks: write
+  # To post comments on PRs
+  issues: write
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -44,6 +57,11 @@ jobs:
         with:
           submodules: recursive
 
+      #      - name: Set up git
+      #        run: |
+      #          git config user.name github-actions
+      #          git config user.email github-actions@github.com
+
       - uses: ./.github/actions/install-deps
 
       - name: Prepare repository
@@ -56,4 +74,5 @@ jobs:
       - name: Create Release
         run: npx auto shipit -vv
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@auto-it/magic-zero": "10.43.0",
         "@auto-it/npm": "10.43.0",
+        "@auto-it/protected-branch": "10.43.0",
         "@auto-it/released": "10.43.0",
         "@auto-it/upload-assets": "10.43.0",
         "@babel/preset-env": "7.20.2",
@@ -7692,6 +7693,25 @@
       "engines": {
         "node": ">=10.x"
       }
+    },
+    "node_modules/@auto-it/protected-branch": {
+      "version": "10.43.0",
+      "resolved": "https://registry.npmjs.org/@auto-it/protected-branch/-/protected-branch-10.43.0.tgz",
+      "integrity": "sha512-uheYqLkd0vVPI2U1kBb/pXPJ8KA5RbvJ0a+VlEgLo+dI4J1WPm67FspPLczMzGKLxb1lCBagGZfM/EKxzoCVuQ==",
+      "dev": true,
+      "dependencies": {
+        "@auto-it/core": "10.43.0",
+        "@octokit/rest": "^18.12.0",
+        "fp-ts": "^2.5.3",
+        "io-ts": "^2.1.2",
+        "tslib": "1.10.0"
+      }
+    },
+    "node_modules/@auto-it/protected-branch/node_modules/tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "node_modules/@auto-it/released": {
       "version": "10.43.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@auto-it/magic-zero": "10.43.0",
     "@auto-it/npm": "10.43.0",
+    "@auto-it/protected-branch": "10.43.0",
     "@auto-it/released": "10.43.0",
     "@auto-it/upload-assets": "10.43.0",
     "@babel/preset-env": "7.20.2",
@@ -87,6 +88,7 @@
     "plugins": [
       "magic-zero",
       "./scripts/build-extension.ts",
+      "protected-branch",
       [
         "upload-assets",
         [


### PR DESCRIPTION
## Motivation

Because of GitHub branch protection, a release commit (changelog + bump) cannot push directly, so I added a plugin to create a PR before releasing instead of push directly

- [release PR](https://github.com/nexus-backup/nexus/pull/3)
- [release example](https://github.com/nexus-backup/nexus/releases/tag/v0.0.2)

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
