### PR TITLE
fix(extension-chrome): fix typo and whitelist UI overflow

### DIFF
--- a/packages/extension-chrome/src/pages/Components/WhiteAlphaBox.tsx
+++ b/packages/extension-chrome/src/pages/Components/WhiteAlphaBox.tsx
@@ -11,7 +11,7 @@ export const WhiteAlphaBox: FC<FlexProps> = ({ children, sx, ...props }) => {
       sx={{
         '::-webkit-scrollbar': {
           backgroundColor: 'transparent',
-          w: '8px',
+          w: '5px',
         },
         '::-webkit-scrollbar-thumb': {
           borderRadius: '30px',

--- a/packages/extension-chrome/src/pages/Notification/utils/WellkownCellManager.tsx
+++ b/packages/extension-chrome/src/pages/Notification/utils/WellkownCellManager.tsx
@@ -18,7 +18,7 @@ for (const cfg of Object.values(config.predefined)) {
     },
     parse(cell: Cell) {
       if (cell.data === DEPOSIT_CELL_DATA) {
-        return 'DAO Diposit';
+        return 'DAO Deposit';
       } else {
         return 'DAO Withdraw';
       }

--- a/packages/extension-chrome/src/pages/Popup/containers/Network/NetworkConfig.tsx
+++ b/packages/extension-chrome/src/pages/Popup/containers/Network/NetworkConfig.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Flex, Spacer, Button, Radio, RadioGroup, Skeleton, Icon, useToast, VStack } from '@chakra-ui/react';
+import { Flex, Spacer, Button, Radio, RadioGroup, Skeleton, Icon, useToast, VStack, Box } from '@chakra-ui/react';
 import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
 import EditIcon from '../../../Components/icons/Edit.svg';
 import { useNavigate } from 'react-router-dom';
@@ -87,7 +87,7 @@ export const NetworkConfig: FC = () => {
                 justifyContent="space-between"
               >
                 <Radio colorScheme="cyan" data-test-id={`networkRadio[${index}]`} value={network.id}>
-                  {network.displayName}
+                  <Box marginLeft="12px">{network.displayName}</Box>
                 </Radio>
                 <Spacer />
                 {!PERSIST_IDS.has(network.id) && (

--- a/packages/extension-chrome/src/pages/Popup/containers/WhitelistSites.tsx
+++ b/packages/extension-chrome/src/pages/Popup/containers/WhitelistSites.tsx
@@ -82,6 +82,7 @@ export const WhitelistSites: FC = () => {
         padding="30px 20px"
         as={WhiteAlphaBox}
         spacing="12px"
+        maxH="288px"
         flexDirection="column"
       >
         {filteredSites?.map((site, index) => (


### PR DESCRIPTION
# What Changed

## Motivation
Fix a typo: `diposit` -> `deposit`

and fix whitelist overflow on UI.

![image](https://user-images.githubusercontent.com/20639676/227155991-88fa3602-64c3-4f93-bd2c-17cc176916f7.png)
![image](https://user-images.githubusercontent.com/20639676/227156045-4017af12-e21e-4b7f-a024-7d76c0cddf9d.png)

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
