### PR TITLE
chore: prevent canary release in PR from forked repo

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,12 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if: |
+      (!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')) &&
+      (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+        github.event_name == 'push'
+      )
     needs: unit-test
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# What Changed

The workflow has been changed to prevent canary release in a PR from a forked repo

examples: 

- https://github.com/nexus-backup/nexus/pull/4
- https://github.com/nexus-backup/nexus/pull/5

## Motivation

We can't be sure if a PR from a fork repository is safe or not, and running the "release" job may cause unexpected security problem

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
