### PR TITLE
refactor: extract request with retry to a stateless function

### DIFF
--- a/packages/extension-chrome/__tests__/services/ownership/backend/request.ts
+++ b/packages/extension-chrome/__tests__/services/ownership/backend/request.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
-import { createRpcClient } from '../../../../src/services/ownership/backend/backendUtils';
+import { requestWithRetries } from '../../../../src/services/ownership/backend/request';
 
 describe('refetch', () => {
   beforeAll(() => {
@@ -11,9 +11,7 @@ describe('refetch', () => {
   it('should refetch when first request fails', async () => {
     fetchMock.mockRejectOnce(new Error('some error'));
     fetchMock.mockResponse(JSON.stringify({ result: 'some result' }));
-    const { request } = createRpcClient('');
-    await request('some_method', {});
-
+    await requestWithRetries(() => fetch('http://dummy'));
     expect(fetch).toBeCalledTimes(2);
   });
 });

--- a/packages/extension-chrome/src/services/ownership/backend/backendUtils.ts
+++ b/packages/extension-chrome/src/services/ownership/backend/backendUtils.ts
@@ -3,7 +3,7 @@ import { asserts } from '@nexus-wallet/utils';
 import { ScriptConfig } from '@ckb-lumos/config-manager';
 import { JSONRPCRequest, JSONRPCResponse } from 'json-rpc-2.0';
 import { RPC as RpcType } from '@ckb-lumos/rpc/lib/types/rpc';
-import { RequestOptions, requestWithOptions } from './request';
+import { RequestOptions, requestWithRetries } from './request';
 import { NexusCommonErrors } from '../../../errors';
 
 type Order = 'asc' | 'desc';
@@ -105,7 +105,7 @@ function createRpcClient(url: string, options?: RequestOptions): RpcClient {
         },
       });
 
-    return requestWithOptions(fetchProvider, options);
+    return requestWithRetries(fetchProvider, options);
   }
 
   async function request<Result = unknown, Params = unknown>(method: string, params: Params): Promise<Result> {

--- a/packages/extension-chrome/src/services/ownership/backend/request.ts
+++ b/packages/extension-chrome/src/services/ownership/backend/request.ts
@@ -8,7 +8,7 @@ export type RequestOptions = {
   maxRetries?: number;
 };
 
-export const requestWithOptions = async (
+export const requestWithRetries = async (
   promiseCtor: () => Promise<Response>,
   options?: RequestOptions,
 ): Promise<JSONRPCResponse | JSONRPCResponse[]> => {

--- a/packages/extension-chrome/src/services/ownership/backend/request.ts
+++ b/packages/extension-chrome/src/services/ownership/backend/request.ts
@@ -1,0 +1,31 @@
+import { JSONRPCResponse } from 'json-rpc-2.0';
+import { NexusCommonErrors } from '../../../errors';
+import pRetry from './thirdpartyLib/p-retry';
+import pTimeout from './thirdpartyLib/p-timeout';
+
+export type RequestOptions = {
+  timeout?: number; // in milliseconds
+  maxRetries?: number;
+};
+
+export const requestWithOptions = async (
+  promiseCtor: () => Promise<Response>,
+  options?: RequestOptions,
+): Promise<JSONRPCResponse | JSONRPCResponse[]> => {
+  const retryRunner = async () => {
+    const res = await promiseCtor();
+    // Abort retrying if the resource doesn't exist
+    if (res.status >= 300) {
+      /* istanbul ignore next */
+      throw NexusCommonErrors.RequestCkbFailed(res);
+    }
+    return res.json();
+  };
+
+  const retryPromise = pRetry(retryRunner, { retries: options?.maxRetries || 5 });
+  const res = await pTimeout(retryPromise, {
+    milliseconds: options?.timeout || 5_000,
+  });
+
+  return res as Promise<JSONRPCResponse | JSONRPCResponse[]>;
+};


### PR DESCRIPTION
# What Changed

This PR refactors extract ownership backend fetch request with retry and timeout to a stateless function. And changed corresponding test case.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
