### PR TITLE
[fix]: script_search_mode bug

### DIFF
--- a/packages/extension-chrome/src/services/ownership/backend/backendUtils.ts
+++ b/packages/extension-chrome/src/services/ownership/backend/backendUtils.ts
@@ -14,7 +14,7 @@ type RpcQueryType = [
   {
     script: RpcType.Script;
     script_type: 'lock' | 'type';
-    search_type: 'exact' | 'prefix';
+    script_search_mode: 'exact' | 'prefix';
   },
   Order,
   Limit,
@@ -34,7 +34,7 @@ const toQueryParam = (payload: {
       args: payload.lock.args,
     },
     script_type: 'lock',
-    search_type: 'exact',
+    script_search_mode: 'exact',
   },
   payload.order ?? 'asc',
   payload.limit ?? '0x64',


### PR DESCRIPTION
# What Changed

## Motivation

This PR resolves the bug introduced by passing in wrong field name of exact search.

should be `script_search_mode`, but was `search_type`

refer to: https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-indexersearchkey

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
