### PR TITLE
fix: getLiveCells returns specified change type cells

### DIFF
--- a/packages/extension-chrome/__tests__/services/ownership/fullOwnership.test.ts
+++ b/packages/extension-chrome/__tests__/services/ownership/fullOwnership.test.ts
@@ -111,6 +111,14 @@ describe('FullOwnership', () => {
       });
     });
 
+    it('should get live cells with cursor', async () => {
+      await ownershipService.getLiveCells({ cursor: '3:0x1234' });
+      expect(backend.getLiveCellsByLocks).toBeCalledWith({
+        cursor: '0x1234',
+        locks: [scriptInfos[3].lock],
+      });
+    });
+
     it('should get live cells with default change', async () => {
       await ownershipService.getLiveCells({});
       expect(backend.getLiveCellsByLocks).toBeCalledWith({

--- a/packages/extension-chrome/__tests__/services/ownership/fullOwnership.test.ts
+++ b/packages/extension-chrome/__tests__/services/ownership/fullOwnership.test.ts
@@ -111,11 +111,27 @@ describe('FullOwnership', () => {
       });
     });
 
-    it('should get live cells', async () => {
+    it('should get live cells with default change', async () => {
       await ownershipService.getLiveCells({});
       expect(backend.getLiveCellsByLocks).toBeCalledWith({
         cursor: '',
         locks: [scriptInfos[1].lock, scriptInfos[3].lock],
+      });
+    });
+
+    it('should get external live cells with change set to external', async () => {
+      await ownershipService.getLiveCells({ change: 'external' });
+      expect(backend.getLiveCellsByLocks).toBeCalledWith({
+        cursor: '',
+        locks: [scriptInfos[1].lock],
+      });
+    });
+
+    it('should get internal live cells with change set to internal', async () => {
+      await ownershipService.getLiveCells({ change: 'internal' });
+      expect(backend.getLiveCellsByLocks).toBeCalledWith({
+        cursor: '',
+        locks: [scriptInfos[3].lock],
       });
     });
 


### PR DESCRIPTION
# What Changed

This PR resolves #164

## Motivation

For now, `wallet_fullOwnership_getLiveCells` returns both `external` and `internal` cells, we need to support the `change` filter.

refer to current code: https://github.com/ckb-js/nexus/blob/45d4787d92d0416400d64ccf219686ca4b5f6db2/packages/extension-chrome/src/services/ownership/fullOwnership.ts#L45-L73

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
