### PR TITLE
feat(extension-chrome): optimize displaying amount of asset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "lumos",
         "lumos/packages/*"
       ],
+      "dependencies": {
+        "numeral": "2.0.6"
+      },
       "devDependencies": {
         "@auto-it/magic-zero": "10.43.0",
         "@auto-it/npm": "10.43.0",
@@ -24,6 +27,7 @@
         "@babel/preset-typescript": "7.18.6",
         "@types/jest": "29.4.0",
         "@types/lodash.times": "4.3.7",
+        "@types/numeral": "2.0.2",
         "@typescript-eslint/eslint-plugin": "5.49.0",
         "@typescript-eslint/parser": "5.49.0",
         "concat-md": "0.5.1",
@@ -13717,6 +13721,12 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/@types/numeral": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-2.0.2.tgz",
+      "integrity": "sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==",
+      "dev": true
+    },
     "node_modules/@types/object-hash": {
       "version": "2.2.1",
       "license": "MIT"
@@ -25967,6 +25977,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/nwsapi": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-typescript": "7.18.6",
     "@types/jest": "29.4.0",
     "@types/lodash.times": "4.3.7",
+    "@types/numeral": "2.0.2",
     "@typescript-eslint/eslint-plugin": "5.49.0",
     "@typescript-eslint/parser": "5.49.0",
     "concat-md": "0.5.1",
@@ -106,5 +107,8 @@
         "releaseType": "none"
       }
     ]
+  },
+  "dependencies": {
+    "numeral": "2.0.6"
   }
 }

--- a/packages/extension-chrome/src/pages/Notification/containers/SignTransaction.tsx
+++ b/packages/extension-chrome/src/pages/Notification/containers/SignTransaction.tsx
@@ -37,6 +37,30 @@ type TransactionIOListProps = {
   networkName?: NetworkName;
 } & TableProps;
 
+const capacityFormatter = new Intl.NumberFormat('en-US', { style: 'decimal' });
+
+const CellCapacity: FC<{ capacity: string }> = ({ capacity }) => {
+  const amount = BI.from(capacity);
+  const integerPart = amount.div(10 ** 8);
+  const hasDecimal = amount.mod(10 ** 8).gt(0);
+
+  const integerFormatted = capacityFormatter.format(integerPart.toBigInt());
+
+  return (
+    <>
+      {hasDecimal ? (
+        <Tooltip hasArrow label={`${capacityFormatter.format(amount.toNumber() / 1e8)} CKB`}>
+          <Box>
+            ≈{integerFormatted}
+            {' CKB'}
+          </Box>
+        </Tooltip>
+      ) : (
+        <Box>{integerFormatted} CKB</Box>
+      )}
+    </>
+  );
+};
 const TransactionIOList: FC<TransactionIOListProps> = ({ type, networkName, tx, ...rest }) => {
   // TODO: a better way to implement: use a config provider to get the config better.
   const lumosConfig = networkName === 'ckb' ? predefined.LINA : predefined.AGGRON4;
@@ -111,10 +135,7 @@ const TransactionIOList: FC<TransactionIOListProps> = ({ type, networkName, tx, 
               </Td>
               <Td data-test-id={`transaction.${type}[${index}].type`}>{parseCellType(cell)}</Td>
               <Td data-test-id={`transaction.${type}[${index}].capacity`}>
-                {BI.from(cell.cellOutput.capacity)
-                  .div(10 ** 8)
-                  .toString()}{' '}
-                CKB
+                <CellCapacity capacity={cell.cellOutput.capacity} />
               </Td>
             </Tr>
           );

--- a/packages/extension-chrome/src/pages/Notification/containers/SignTransaction.tsx
+++ b/packages/extension-chrome/src/pages/Notification/containers/SignTransaction.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {
   Table,
   Skeleton,
@@ -19,8 +20,8 @@ import {
   Spacer,
   Tooltip,
 } from '@chakra-ui/react';
+import numeral from 'numeral';
 import { encodeToAddress, TransactionSkeletonObject } from '@ckb-lumos/helpers';
-import { BI } from '@ckb-lumos/lumos';
 import { predefined } from '@ckb-lumos/config-manager';
 import { useQuery } from '@tanstack/react-query';
 import React, { FC, useMemo } from 'react';
@@ -30,6 +31,7 @@ import { useSessionMessenger } from '../../hooks/useSessionMessenger';
 import { parseCellType } from '../utils/parseCellType';
 import { useConfigQuery } from '../../hooks/useConfigQuery';
 import { NetworkName } from '@nexus-wallet/protocol';
+import { formatUnit } from '@ckb-lumos/bi';
 
 type TransactionIOListProps = {
   type: 'inputs' | 'outputs';
@@ -37,26 +39,22 @@ type TransactionIOListProps = {
   networkName?: NetworkName;
 } & TableProps;
 
-const capacityFormatter = new Intl.NumberFormat('en-US', { style: 'decimal' });
-
 const CellCapacity: FC<{ capacity: string }> = ({ capacity }) => {
-  const amount = BI.from(capacity);
-  const integerPart = amount.div(10 ** 8);
-  const hasDecimal = amount.mod(10 ** 8).gt(0);
+  const amount = numeral(formatUnit(capacity, 'ckb')).format('0,0[.][00000000]');
 
-  const integerFormatted = capacityFormatter.format(integerPart.toBigInt());
+  const [integerPart, decimalPart = ''] = amount.split('.');
 
   return (
     <>
-      {hasDecimal ? (
-        <Tooltip hasArrow label={`${capacityFormatter.format(amount.toNumber() / 1e8)} CKB`}>
+      {decimalPart ? (
+        <Tooltip hasArrow label={`${amount} CKB`}>
           <Box>
-            ≈{integerFormatted}
+            ≈{integerPart}
             {' CKB'}
           </Box>
         </Tooltip>
       ) : (
-        <Box>{integerFormatted} CKB</Box>
+        <Box>{amount} CKB</Box>
       )}
     </>
   );


### PR DESCRIPTION
# What Changed
![image](https://user-images.githubusercontent.com/20639676/230317045-fa9b13e6-f3b8-4320-a058-55fb90857061.png)
closes #181

## Motivation
Current transaction information on transaction request notification do not show the decimal part.

It is very vague to our users. Seems like my CKB is missing when transaction occurs.
## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[nexus--canary.187.4628332043.zip](https://github.com/ckb-js/nexus/releases/download/v0.0.0-canary/nexus--canary.187.4628332043.zip)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
