### PR TITLE
chore: avoid canary for renovate pr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "addLabels": ["dependencies"]
 }


### PR DESCRIPTION
# What Changed

- auto labeling for renovate PRs

## Motivation

To avoid canary release for renovate PRs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
