### PR TITLE
refactor: batch sign message with keystore service

### DIFF
--- a/packages/extension-chrome/__tests__/services/keystore.test.ts
+++ b/packages/extension-chrome/__tests__/services/keystore.test.ts
@@ -98,8 +98,7 @@ describe('KeystoreService', () => {
 
     const child = fixture.derived[1];
     const signMessagePromise = service.signMessage({
-      path: child.path,
-      message: mockedMessage,
+      messageInfos: [{ path: child.path, message: mockedMessage }],
       password: MOCK_PLATFORM_PASSWORD,
     });
     await expect(Promise.resolve(signMessagePromise)).resolves.not.toThrowError();
@@ -110,7 +109,10 @@ describe('KeystoreService', () => {
 
   test('should throw when the password is incorrect', async () => {
     await expect(
-      service.signMessage({ path: `m/44'/309'/0'/0/0`, message: '0x00', password: 'incorrect password' }),
+      service.signMessage({
+        messageInfos: [{ path: `m/44'/309'/0'/0/0`, message: '0x00' }],
+        password: 'incorrect password',
+      }),
     ).rejects.toThrow();
   });
 

--- a/packages/extension-chrome/__tests__/services/ownership/fullOwnership.test.ts
+++ b/packages/extension-chrome/__tests__/services/ownership/fullOwnership.test.ts
@@ -144,9 +144,13 @@ describe('FullOwnership', () => {
     it('should signData by keystore service with proper params', async () => {
       await ownershipService.signData({ data: '0x1234', lock: scriptInfos[0].lock, url: MOCK_PLATFORM_URL });
       expect(keystoreService.signMessage).toBeCalledWith({
-        message: bytes.hexify(bytes.concat(SIGN_DATA_MAGIC, '0x1234')),
+        messageInfos: [
+          {
+            message: bytes.hexify(bytes.concat(SIGN_DATA_MAGIC, '0x1234')),
+            path: `${scriptInfos[0].parentPath}/${scriptInfos[0].childIndex}`,
+          },
+        ],
         password: '12345678',
-        path: `${scriptInfos[0].parentPath}/${scriptInfos[0].childIndex}`,
       });
       jest.clearAllMocks();
     });
@@ -154,16 +158,19 @@ describe('FullOwnership', () => {
     it('should signTx by keystore service with proper params', async () => {
       jest.spyOn(common, 'prepareSigningEntries').mockImplementation(() => createMockTxSkeleton());
       await ownershipService.signTransaction({ tx: {} as Transaction, url: MOCK_PLATFORM_URL });
-      expect(keystoreService.signMessage).toHaveBeenCalledTimes(2);
+      expect(keystoreService.signMessage).toHaveBeenCalledTimes(1);
       expect(keystoreService.signMessage).nthCalledWith(1, {
-        message: '0x1234',
+        messageInfos: [
+          {
+            message: '0x1234',
+            path: "m/44'/309'/0'/0/0",
+          },
+          {
+            message: '0x5678',
+            path: "m/44'/309'/0'/0/0",
+          },
+        ],
         password: '12345678',
-        path: `${scriptInfos[0].parentPath}/${scriptInfos[0].childIndex}`,
-      });
-      expect(keystoreService.signMessage).nthCalledWith(2, {
-        message: '0x5678',
-        password: '12345678',
-        path: `${scriptInfos[1].parentPath}/${scriptInfos[1].childIndex}`,
       });
       jest.clearAllMocks();
     });

--- a/packages/extension-chrome/src/services/keystore/keystore.ts
+++ b/packages/extension-chrome/src/services/keystore/keystore.ts
@@ -94,16 +94,17 @@ export function createKeystoreService(config: { storage: Storage<KeystoreData> }
       return storage.hasItem('keystore');
     },
 
-    signMessage: async (payload: SignMessagePayload): Promise<HexString> => {
+    signMessage: async (payload: SignMessagePayload): Promise<HexString[]> => {
       const keystoreData = await resolveKeystoreData();
-
       const keystore = Keystore.fromJson(keystoreData.wss);
       const extendedPrivateKey = keystore.extendedPrivateKey(await resolveValue(payload.password));
 
-      return key.signRecoverable(
-        bytes.hexify(payload.message),
-        extendedPrivateKey.privateKeyInfoByPath(payload.path).privateKey,
-      );
+      return payload.messageInfos.map((messageInfo) => {
+        return key.signRecoverable(
+          bytes.hexify(messageInfo.message),
+          extendedPrivateKey.privateKeyInfoByPath(messageInfo.path).privateKey,
+        );
+      });
     },
 
     reset: async () => {

--- a/packages/types/src/services/KeystoreService.ts
+++ b/packages/types/src/services/KeystoreService.ts
@@ -32,7 +32,7 @@ export interface KeystoreService {
    *
    * @param payload {@link SignMessagePayload}
    */
-  signMessage(payload: SignMessagePayload): Promisable<HexString>;
+  signMessage(payload: SignMessagePayload): Promisable<HexString[]>;
 
   /**
    * clear all data about the keystore, including the mnemonic, extended public keys, etc.
@@ -76,7 +76,7 @@ export interface InitKeystorePayload {
   paths: NonHardenedPath[];
 }
 
-export interface SignMessagePayload {
+interface MessageInfo {
   /**
    * message be to signed
    */
@@ -85,6 +85,10 @@ export interface SignMessagePayload {
    * derivation path of the private key, will be used to sign the message
    */
   path: HardenedPath | NonHardenedPath;
+}
+
+export interface SignMessagePayload {
+  messageInfos: MessageInfo[];
   /**
    * password to decrypt the keystore
    */


### PR DESCRIPTION
# What Changed

This PR resovles #222 

## Motivation

It takes too long to sign a big transaction containing many inputs with different locks. 

For example, on my machine, it takes about 1 minute to sign a transaction with 30 inputs.

Currently it's because every signature is generated separately, I have tried to figure out which step we can optimize by logging the time elapsed:

```typescript
// KeystoreService.ts
signMessage: async (payload: SignMessagePayload): Promise<HexString> => {
+   const startTime = Date.now();
    const keystoreData = await resolveKeystoreData();
+   const step1 = Date.now();

    const keystore = Keystore.fromJson(keystoreData.wss);
+   const step2 = Date.now();

    const extendedPrivateKey = keystore.extendedPrivateKey(await resolveValue(payload.password));
+   const step3 = Date.now();

    const result =  key.signRecoverable(
      bytes.hexify(payload.message),
      extendedPrivateKey.privateKeyInfoByPath(payload.path).privateKey,
    );
+   const step4 = Date.now();
+   console.log('resolve keystore service time:', step1 - startTime);
+   console.log('read keystore from json:', step2 - step1);
+   console.log('extend privatekey:', step3 - step2);
+   console.log('sign:', step4 - step3);
    return result;
}
```

and the sample result: 

```
keystore.ts:113 resolve keystore service time: 13
keystore.ts:114 read keystore from json: 0
keystore.ts:115 extend privatekey: 1856
keystore.ts:116 sign: 22

keystore.ts:113 resolve keystore service time: 18
keystore.ts:114 read keystore from json: 0
keystore.ts:115 extend privatekey: 1853
keystore.ts:116 sign: 8
```

which means getting `extendedPrivateKey` takes most of time, by batching the sign requests,
we just need to generate `extendedPrivateKey` once in signing one tx, much improving the performance.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
