### PR TITLE
fix(ownership-providers): inject witness and cellDeps auto

### DIFF
--- a/packages/ownership-providers/__tests__/FullOwnershipProvider.test.ts
+++ b/packages/ownership-providers/__tests__/FullOwnershipProvider.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BI, BIish, parseUnit } from '@ckb-lumos/bi';
-import { parseAddress, TransactionSkeleton, TransactionSkeletonType } from '@ckb-lumos/helpers';
+import { TransactionSkeleton, TransactionSkeletonType } from '@ckb-lumos/helpers';
 import { common, secp256k1Blake160 } from '@ckb-lumos/common-scripts';
 import { Cell, Script } from '@nexus-wallet/protocol';
 import { predefined } from '@ckb-lumos/config-manager';
@@ -220,6 +220,7 @@ describe('class FullOwnershipProvider', () => {
 
       return provider;
     }
+
     function createFakeSkeleton(inputCells: Cell[], outputCells: Cell[]) {
       const txSkeleton = TransactionSkeleton();
       return txSkeleton
@@ -498,28 +499,6 @@ describe('class FullOwnershipProvider', () => {
   it('#getLumosConfig', async () => {
     const provider = new FullOwnershipProvider(mockProviderConfig);
     await expect(provider['getLumosConfig']()).resolves.toBe(predefined.LINA);
-  });
-
-  describe('#parseLockScriptLike', () => {
-    it('Should parse address', async () => {
-      const provider = new FullOwnershipProvider(mockProviderConfig);
-      provider['getLumosConfig'] = jest.fn().mockResolvedValue(predefined.AGGRON4);
-      await expect(
-        provider['parseLockScriptLike'](
-          'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqgxvk9qlymu894vugvgflwa967zjvud07qq4x3kf',
-        ),
-      ).resolves.toEqual(
-        parseAddress(
-          'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqgxvk9qlymu894vugvgflwa967zjvud07qq4x3kf',
-          { config: predefined.AGGRON4 },
-        ),
-      );
-    });
-
-    it('Should return origin lock when input is a lock script', async () => {
-      const provider = new FullOwnershipProvider(mockProviderConfig);
-      await expect(provider['parseLockScriptLike'](onChainLocks1)).resolves.toBe(onChainLocks1);
-    });
   });
 
   it('#getOffChainLocks and #getOnChainLocks', async () => {

--- a/packages/ownership-providers/jest.config.js
+++ b/packages/ownership-providers/jest.config.js
@@ -2,12 +2,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  moduleNameMapper: {
-    // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports.
-    // See https://github.com/uuidjs/uuid/issues/451
-    uuid: require.resolve('uuid'),
-
-    '@vespaiach/axios-fetch-adapter': '<rootDir>/__mocks__/axiosAdapter.js',
-  },
-  testMatch: ['**/__tests__/**/*.test.ts'],
 };

--- a/packages/ownership-providers/src/FullOwnershipProvider.ts
+++ b/packages/ownership-providers/src/FullOwnershipProvider.ts
@@ -185,7 +185,20 @@ export class FullOwnershipProvider {
         return inputs.push(...injectedCells);
       })
       .update('witnesses', (witnesses) => {
-        const inputWitnesses = injectedCells.map(() => SECP256K1_BLAKE160_WITNESS_PLACEHOLDER);
+        const serializedCellLocks = new Set(
+          txSkeleton
+            .get('inputs')
+            .toArray()
+            .map((cell) => bytes.hexify(blockchain.Script.pack(cell.cellOutput.lock))),
+        );
+        const inputWitnesses = injectedCells.map((cell) => {
+          const serializedCellLock = bytes.hexify(blockchain.Script.pack(cell.cellOutput.lock));
+          if (serializedCellLocks.has(serializedCellLock)) {
+            return '0x';
+          }
+          serializedCellLocks.add(serializedCellLock);
+          return SECP256K1_BLAKE160_WITNESS_PLACEHOLDER;
+        });
         return witnesses.push(...inputWitnesses);
       })
       .update('outputs', (outputs) => {

--- a/packages/ownership-providers/src/FullOwnershipProvider.ts
+++ b/packages/ownership-providers/src/FullOwnershipProvider.ts
@@ -5,7 +5,6 @@ import { assert, errors } from '@nexus-wallet/utils';
 import {
   createTransactionFromSkeleton,
   minimalCellCapacityCompatible,
-  parseAddress,
   TransactionSkeletonType,
 } from '@ckb-lumos/helpers';
 import { Address, blockchain, Cell, CellDep, HexString, Script, Transaction } from '@ckb-lumos/base';
@@ -387,14 +386,5 @@ export class FullOwnershipProvider {
   // TODO: wait for wallet provide a API to get genesis block hash
   private async getLumosConfig(): Promise<LumosConfig> {
     return getLumosConfig();
-  }
-
-  private async parseLockScriptLike(lock: LockScriptLike) {
-    if (typeof lock === 'object') {
-      return lock;
-    }
-
-    const config = await this.getLumosConfig();
-    return parseAddress(lock, { config });
   }
 }

--- a/packages/ownership-providers/tsconfig.json
+++ b/packages/ownership-providers/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "outDir": "lib",
-    "lib": ["DOM"]
+    "outDir": "lib"
   },
   "include": ["src"],
   "exclude": ["__tests__"]

--- a/packages/ownership-providers/tsconfig.test.json
+++ b/packages/ownership-providers/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["__tests__"]
+}


### PR DESCRIPTION
# What Changed

Resolve #248 

## Motivation

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[nexus--canary.251.4787742070.zip](https://github.com/ckb-js/nexus/releases/download/v0.0.0-canary/nexus--canary.251.4787742070.zip)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.16--canary.251.4787742070.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nexus-wallet/ownership-providers@0.0.16--canary.251.4787742070.0
  npm install @nexus-wallet/protocol@0.0.16--canary.251.4787742070.0
  npm install @nexus-wallet/utils@0.0.16--canary.251.4787742070.0
  # or 
  yarn add @nexus-wallet/ownership-providers@0.0.16--canary.251.4787742070.0
  yarn add @nexus-wallet/protocol@0.0.16--canary.251.4787742070.0
  yarn add @nexus-wallet/utils@0.0.16--canary.251.4787742070.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
