### PR TITLE
chore: fix release error in pipeline

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+npm run build:libs
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
       "prettier --write --ignore-unknown"
     ],
     "**/*.{js,jsx,ts,tsx}": [
-      "npm run build:libs",
       "npx eslint"
     ],
     "packages/protocol/**/*": [


### PR DESCRIPTION
# What Changed
Fix [Pipeline Error](https://github.com/ckb-js/nexus/actions/runs/4872491982/jobs/8704633162) on release.
This PR move `npm run build:libs` to husky from lint-staged.
## Motivation
lint-staged pass `/home/runner/work/nexus/nexus/packages/utils/src/env.ts` to lerna command, and it throws this error:
```
✖ npm run build:libs:
ERR! lerna Unknown argument: /home/runner/work/nexus/nexus/packages/utils/src/env.ts

> @nexus-wallet/nexus@0.0.0 build:libs
> lerna run build --ignore '@nexus-wallet/extension-chrome' /home/runner/work/nexus/nexus/packages/utils/src/env.ts
```
Indeed, lint stage is only for check files in git stage. `npm run build:libs` is just a preparing step before check files in stage.
## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[nexus--canary.276.4879071928.zip](https://github.com/ckb-js/nexus/releases/download/v0.0.0-canary/nexus--canary.276.4879071928.zip)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.19--canary.276.4879071928.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nexus-wallet/detect-ckb@0.0.19--canary.276.4879071928.0
  npm install @nexus-wallet/ownership-providers@0.0.19--canary.276.4879071928.0
  npm install @nexus-wallet/protocol@0.0.19--canary.276.4879071928.0
  npm install @nexus-wallet/utils@0.0.19--canary.276.4879071928.0
  # or 
  yarn add @nexus-wallet/detect-ckb@0.0.19--canary.276.4879071928.0
  yarn add @nexus-wallet/ownership-providers@0.0.19--canary.276.4879071928.0
  yarn add @nexus-wallet/protocol@0.0.19--canary.276.4879071928.0
  yarn add @nexus-wallet/utils@0.0.19--canary.276.4879071928.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
