### PR TITLE
test: Fix e2e faild by CSP

### DIFF
--- a/e2e/helpers/DefaultTestEnv.ts
+++ b/e2e/helpers/DefaultTestEnv.ts
@@ -122,6 +122,7 @@ export class DefaultTestEnv implements TestEnv {
     this._context = await chromium.launchPersistentContext(persistentPath, {
       headless: this.options.headless,
       slowMo: 10,
+      bypassCSP: true,
       args: [
         ...(this.options.headless ? ['--headless=new'] : []),
         `--disable-extensions-except=${this.options.extensionDirPath}`,

--- a/e2e/tests/wallet-enable.test.ts
+++ b/e2e/tests/wallet-enable.test.ts
@@ -2,6 +2,7 @@ import { DefaultTestEnv } from '../helpers';
 
 DefaultTestEnv.setupTest({ initWalletWithDefaults: true });
 
+jest.setTimeout(20_000);
 describe('Enable wallet', function () {
   test('should get the nickname when approved', async () => {
     const enableTask = ckb.request({ method: 'wallet_enable' });

--- a/packages/extension-chrome/public/manifest.json
+++ b/packages/extension-chrome/public/manifest.json
@@ -19,6 +19,9 @@
       "run_at": "document_start"
     }
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self';"
+  },
   "web_accessible_resources": [
     {
       "resources": ["inpage.js", "inpage.js.map"],


### PR DESCRIPTION
# What Changed
Modify extension page CSP.

## Motivation
Like [this](
Like https://github.com/ckb-js/nexus/actions/runs/4881193194/jobs/8710084656?pr=237) pipe line error. It throws an timeout Error. I rerun the case in the local.
In newer Chrome version, unsafe eval is restricted. Unless CSP allow to execute it.
, Our E2E test need evaluate some code on extension page. But it is be blocked. So the e2e failed. Seems like a timeout error. 
## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[nexus--canary.279.4884117458.zip](https://github.com/ckb-js/nexus/releases/download/v0.0.0-canary/nexus--canary.279.4884117458.zip)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.20--canary.279.4884117458.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nexus-wallet/detect-ckb@0.0.20--canary.279.4884117458.0
  npm install @nexus-wallet/ownership-providers@0.0.20--canary.279.4884117458.0
  npm install @nexus-wallet/protocol@0.0.20--canary.279.4884117458.0
  npm install @nexus-wallet/utils@0.0.20--canary.279.4884117458.0
  # or 
  yarn add @nexus-wallet/detect-ckb@0.0.20--canary.279.4884117458.0
  yarn add @nexus-wallet/ownership-providers@0.0.20--canary.279.4884117458.0
  yarn add @nexus-wallet/protocol@0.0.20--canary.279.4884117458.0
  yarn add @nexus-wallet/utils@0.0.20--canary.279.4884117458.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
